### PR TITLE
feat(daily_arxiv): add request timeout to external API calls

### DIFF
--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -12,6 +12,7 @@ logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%
 
 base_url = "https://arxiv.paperswithcode.com/api/v0/papers/"
 github_url = "https://api.github.com/search/repositories"
+REQUEST_TIMEOUT = 10
 
 
 def load_config(config_file: str) -> dict:
@@ -77,7 +78,7 @@ def get_code_link(qword: str) -> str:
     # query = f"arxiv:{arxiv_id}"
     query = f"{qword}"
     params = {"q": query, "sort": "stars", "order": "desc"}
-    r = requests.get(github_url, params=params)
+    r = requests.get(github_url, params=params, timeout=REQUEST_TIMEOUT)
     results = r.json()
     code_link = None
     if results["total_count"] > 0:
@@ -121,7 +122,7 @@ def get_daily_papers(topic, query="nlp", max_results=2):
 
         try:
             # source code link
-            r = requests.get(code_url).json()
+            r = requests.get(code_url, timeout=REQUEST_TIMEOUT).json()
             repo_url = None
             if "official" in r and r["official"]:
                 repo_url = r["official"]["url"]
@@ -184,7 +185,7 @@ def update_paper_links(filename):
                     continue
                 try:
                     code_url = base_url + paper_id  # TODO
-                    r = requests.get(code_url).json()
+                    r = requests.get(code_url, timeout=REQUEST_TIMEOUT).json()
                     repo_url = None
                     if "official" in r and r["official"]:
                         repo_url = r["official"]["url"]


### PR DESCRIPTION
## Summary
- `requests.get` 호출 3곳 모두에 `timeout=10s` 추가 (`get_code_link`, `get_daily_papers`, `update_paper_links`)
- 모듈 상수 `REQUEST_TIMEOUT = 10` 으로 일괄 관리
- arxiv / paperswithcode / github API 응답 지연 시 GitHub Actions cron이 6시간 잡 한도까지 멈추는 위험 제거

## Why
기본 `requests` 타임아웃이 무한이라, 외부 API 한 곳이라도 응답하지 않으면 12시간 cron이 통째로 멈출 수 있었음. 실패한 논문은 다음 cron에서 재시도되므로 fail-soft 정책.

## Test plan
- [x] `python -m py_compile daily_arxiv.py` 통과
- [ ] 다음 12시간 cron 실행 결과 정상 동작 확인
- [ ] 추후 광범위 except 분리 시 `requests.exceptions.Timeout` 별도 처리 추가 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)