### PR TITLE
ci: use ubuntu-latest runner for check-lint

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   check-lint:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
- `check-lint` 워크플로우의 runner를 `[self-hosted, linux]`에서 `ubuntu-latest`로 변경

## Test plan
- [ ] PR 생성 후 check-lint 워크플로우가 ubuntu-latest 러너에서 정상 실행되는지 확인