### PR TITLE
feat(daily_arxiv): best-effort code-link lookup via HF Papers + abstract regex

### DIFF
--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -5,10 +5,15 @@ import logging
 import re
 
 import arxiv
+import requests
 import yaml
 
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO)
+
+HF_PAPERS_API = "https://huggingface.co/api/papers/"
+REQUEST_TIMEOUT = 10
+GITHUB_URL_RE = re.compile(r"https?://github\.com/[\w.-]+/[\w.-]+")
 
 
 def load_config(config_file: str) -> dict:
@@ -65,6 +70,28 @@ def sort_papers(papers):
     return output
 
 
+def find_code_link(arxiv_id: str, summary: str | None = None) -> str | None:
+    """
+    Best-effort code repo URL lookup. Returns None when nothing is found.
+    Order: HuggingFace Papers `githubRepo` → github.com URL in arxiv summary.
+    """
+    try:
+        r = requests.get(f"{HF_PAPERS_API}{arxiv_id}", timeout=REQUEST_TIMEOUT)
+        if r.status_code == 200:
+            repo = r.json().get("githubRepo")
+            if repo:
+                return repo
+    except requests.RequestException as e:
+        logging.warning(f"HF Papers lookup failed for {arxiv_id}: {e}")
+
+    if summary:
+        m = GITHUB_URL_RE.search(summary)
+        if m:
+            return m.group(0).rstrip(".,);")
+
+    return None
+
+
 def get_daily_papers(topic, query="nlp", max_results=2):
     """
     @param topic: str
@@ -92,14 +119,17 @@ def get_daily_papers(topic, query="nlp", max_results=2):
         else:
             paper_key = paper_id[0:ver_pos]
 
-        # Code 컬럼은 항상 |null| — paperswithcode 종료 후 lookup 소스 없음.
-        # 기존 JSON 의 [link] 가 있는 행과 한 테이블에 섞여도 컬럼 수가 일치해 렌더링 OK.
-        content[paper_key] = "|**{}**|**{}**|{} et.al.|[{}]({})|null|\n".format(
-            update_time, paper_title, paper_first_author, paper_id, paper_url
+        code_link = find_code_link(paper_key, summary=result.summary)
+        code_md = f"**[link]({code_link})**" if code_link else "null"
+        content[paper_key] = "|**{}**|**{}**|{} et.al.|[{}]({})|{}|\n".format(
+            update_time, paper_title, paper_first_author, paper_id, paper_url, code_md
         )
-        content_to_web[paper_key] = "- {}, **{}**, {} et.al., Paper: [{}]({})\n".format(
+        web_line = "- {}, **{}**, {} et.al., Paper: [{}]({})".format(
             update_time, paper_title, paper_first_author, paper_url, paper_url
         )
+        if code_link:
+            web_line += f", Code: **[{code_link}]({code_link})**"
+        content_to_web[paper_key] = web_line + "\n"
 
     data = {topic: content}
     data_web = {topic: content_to_web}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13,<3.14"
 dependencies = [
   "arxiv==3.0.0",
   "pyyaml==6.0.3",
+  "requests==2.33.1",
 ]
 
 [dependency-groups]

--- a/tests/test_daily_arxiv.py
+++ b/tests/test_daily_arxiv.py
@@ -1,8 +1,10 @@
 import textwrap
 
 import pytest
+import requests
 
-from daily_arxiv import get_authors, load_config, sort_papers
+import daily_arxiv
+from daily_arxiv import find_code_link, get_authors, load_config, sort_papers
 
 
 class TestGetAuthors:
@@ -88,3 +90,58 @@ class TestLoadConfig:
     def test_single_word_filter_left_unquoted(self, config_file):
         config = load_config(config_file)
         assert config["kv"]["QA"] == "QA"
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class TestFindCodeLink:
+    def _patch_get(self, monkeypatch, *, status_code=200, payload=None, raises=None):
+        calls = []
+
+        def fake_get(url, timeout=None):
+            calls.append(url)
+            if raises is not None:
+                raise raises
+            return _FakeResponse(status_code, payload)
+
+        monkeypatch.setattr(daily_arxiv.requests, "get", fake_get)
+        return calls
+
+    def test_returns_hf_github_repo_when_present(self, monkeypatch):
+        self._patch_get(monkeypatch, payload={"githubRepo": "https://github.com/foo/bar"})
+        assert find_code_link("2307.09288") == "https://github.com/foo/bar"
+
+    def test_falls_back_to_summary_regex_when_hf_has_no_repo(self, monkeypatch):
+        self._patch_get(monkeypatch, payload={"title": "...", "githubRepo": None})
+        summary = "Code is available at https://github.com/acme/proj for reproducibility."
+        assert find_code_link("2604.21637", summary=summary) == "https://github.com/acme/proj"
+
+    def test_falls_back_to_summary_regex_on_404(self, monkeypatch):
+        self._patch_get(monkeypatch, status_code=404, payload={"error": "not found"})
+        summary = "See https://github.com/acme/proj."
+        assert find_code_link("9999.00000", summary=summary) == "https://github.com/acme/proj"
+
+    def test_falls_back_to_summary_regex_on_network_error(self, monkeypatch):
+        self._patch_get(monkeypatch, raises=requests.ConnectionError("dns"))
+        summary = "Repo: https://github.com/acme/proj"
+        assert find_code_link("2604.21637", summary=summary) == "https://github.com/acme/proj"
+
+    def test_returns_none_when_nothing_matches(self, monkeypatch):
+        self._patch_get(monkeypatch, status_code=404)
+        assert find_code_link("9999.00000", summary="No code link here.") is None
+
+    def test_returns_none_when_summary_missing_and_hf_empty(self, monkeypatch):
+        self._patch_get(monkeypatch, payload={})
+        assert find_code_link("2604.21637") is None
+
+    def test_strips_trailing_punctuation_from_summary_url(self, monkeypatch):
+        self._patch_get(monkeypatch, status_code=404)
+        summary = "We release code at https://github.com/acme/proj)."
+        assert find_code_link("9999.00000", summary=summary) == "https://github.com/acme/proj"

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "arxiv" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -146,6 +147,7 @@ test = [
 requires-dist = [
     { name = "arxiv", specifier = "==3.0.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "requests", specifier = "==2.33.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Why

paperswithcode 제거(#13) 이후 Code 컬럼이 새 entry 마다 항상 `|null|` 인 상태였습니다. PwC 의 1:1 등가 대체재는 없지만, 실측 기반으로 두 가지 신호가 의미 있는 coverage 를 줍니다:

1. **HuggingFace Papers API** — arxiv 의 abs 사이드바가 PwC 후속으로 채택한 곳. `/api/papers/<arxiv_id>` 응답의 `githubRepo` 필드.
2. **arxiv abstract regex** — 저자가 abstract 에 `github.com/...` URL 을 직접 적은 경우 (자가 공개).

두 신호 모두 실패하면 기존처럼 `|null|`. 네트워크/JSON 에러는 좁게 잡고 (`requests.RequestException`) WARNING 로그로 폴백.

## 실측 coverage (cs.CL n=30, 오늘/1주/3주)

| 시점 | HF `githubRepo` | abstract regex |
|---|---|---|
| 오늘 | 0/10 | 0/10 |
| 1주 전 | 0/10 | 2/10 |
| 3주 전 | 1/10 | 0/10 |

신규 논문은 ~5-10%, 인기 논문(LLaMA 2 등)은 깔끔히 해결.

## 변경 사항

- `daily_arxiv.py`
  - `find_code_link(arxiv_id, summary)` 헬퍼 추가 — HF → regex → None
  - `get_daily_papers` 에서 호출, 발견 시 `**[link](url)**` 로 라인 채움
  - `requests` import 복귀, `REQUEST_TIMEOUT=10` 상수, `GITHUB_URL_RE` 정규식
- `pyproject.toml` — `requests==2.33.1` 직접 의존성 재추가 (HF API 직접 호출)
- `tests/test_daily_arxiv.py` — `TestFindCodeLink` 7 케이스 (monkeypatch 기반, 네트워크 없음)

## 비채택 (실측 근거)

- **HF `/api/arxiv/{id}/repos`**: 신규 cs.CL 0% coverage. 추가 호출 비용 대비 효과 미미.
- **GitHub Search API**: LLaMA 2 검색 시 0★ fork 가 1위, 공식 `facebookresearch/llama` 누락. 거짓 매칭이 null 보다 나쁨.
- **Semantic Scholar / OpenAlex**: 코드 레포 필드 자체 없음.
- **주 1회 재확인 cron**: 본 PR scope 외. 필요 시 별도 티켓.

## 검증

- [x] `make check-lock` / `make quality` / `make test`
- [x] 17 단위 테스트 통과 (10 prior + 7 new)
- [x] 실 HF API smoke: `find_code_link('2307.09288')` → `https://github.com/facebookresearch/llama`
- [x] `get_daily_papers('NLP', max_results=2)` 실행 시 정상 동작 (현재 인기 NLP 논문은 신규라 null, 정상)
- [ ] 다음 자동 cron 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)