### PR TITLE
test: add integration tests against real arxiv + HF Papers APIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Run tests
+      - name: Run unit tests
         run: make test
+
+      - name: Run integration tests
+        run: make test-integration

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ quality: set-style-dep check-quality
 style: set-style-dep set-style
 setup: set-git set-dev set-style-dep set-test-dep set-precommit
 test: set-test-dep set-test
+test-integration: set-test-dep set-test-integration
 
 
 ##### basic #####
@@ -23,6 +24,9 @@ set-dev:
 
 set-test:
 	uv run --frozen --group test pytest tests/
+
+set-test-integration:
+	uv run --frozen --group test pytest -m integration tests/
 
 set-style:
 	uv run --frozen --only-group quality ruff check --fix .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ quality = ["pre-commit==4.6.0", "ruff==0.15.12"]
 package = false
 
 [tool.pytest.ini_options]
-addopts = "-ra -v -l"
+addopts = "-ra -v -l -m 'not integration'"
+markers = [
+  "integration: 실제 외부 API/네트워크 호출이 필요한 통합 테스트 (arxiv, HF Papers)",
+]
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,53 @@
+import arxiv
+import pytest
+
+from daily_arxiv import get_daily_papers
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_arxiv_search_smoke():
+    """arxiv API가 응답하고 Result 객체가 우리가 사용하는 필드를 모두 노출하는지."""
+    client = arxiv.Client()
+    search = arxiv.Search(
+        query="NLP",
+        max_results=2,
+        sort_by=arxiv.SortCriterion.SubmittedDate,
+    )
+    results = list(client.results(search))
+
+    assert len(results) > 0, "arxiv returned no results for query='NLP'"
+
+    for r in results:
+        assert r.title
+        assert r.entry_id
+        assert r.authors and len(r.authors) > 0
+        assert r.updated is not None
+        assert r.published is not None
+        assert r.primary_category
+        assert r.get_short_id()
+
+
+def test_get_daily_papers_end_to_end():
+    """get_daily_papers가 arxiv + HF Papers 호출을 거쳐 markdown 라인을 생성하는지."""
+    data, data_web = get_daily_papers("NLP", query="NLP", max_results=2)
+
+    assert "NLP" in data
+    assert "NLP" in data_web
+
+    papers = data["NLP"]
+    web_papers = data_web["NLP"]
+
+    assert len(papers) > 0, "get_daily_papers returned 0 entries"
+    assert set(papers.keys()) == set(web_papers.keys())
+
+    for line in papers.values():
+        assert line.startswith("|**"), f"unexpected row prefix: {line!r}"
+        assert "et.al." in line
+        assert "|[link](" in line or "|null|" in line
+
+    for line in web_papers.values():
+        assert line.startswith("- ")
+        assert "et.al." in line
+        assert "Paper: [" in line


### PR DESCRIPTION
## Summary
- Add `integration` pytest marker; default `pytest` skips it via `-m 'not integration'`
- New `tests/test_integration.py`: arxiv smoke + `get_daily_papers` end-to-end (calls real APIs)
- Makefile: `test-integration` target → `pytest -m integration`
- CI (`test.yml`): run integration tests as a separate step after unit tests

Unit tests verify behavior with mocks; integration tests catch external API breakages (schema drift, endpoint removal) that mocks can't — the recent paperswithcode shutdown is exactly the class of failure these tests would catch.

## Test plan
- [x] `make test` — 17 unit tests pass (integration deselected)
- [x] `make test-integration` — 2 integration tests pass against live arxiv + HF Papers
- [x] `make check-quality` — ruff lint + format clean
- [ ] CI green on this PR