### PR TITLE
fix(daily_arxiv): guard update_json_file against missing file on first run

### DIFF
--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import json
 import logging
+import os
 import re
 
 import arxiv
@@ -140,12 +141,12 @@ def update_json_file(filename, data_dict):
     """
     daily update json file using data_dict
     """
-    with open(filename, "r") as f:
-        content = f.read()
-        if not content:
-            m = {}
-        else:
-            m = json.loads(content)
+    if os.path.exists(filename):
+        with open(filename, "r") as f:
+            content = f.read()
+        m = json.loads(content) if content else {}
+    else:
+        m = {}
 
     json_data = m.copy()
 

--- a/tests/test_daily_arxiv.py
+++ b/tests/test_daily_arxiv.py
@@ -1,10 +1,11 @@
+import json
 import textwrap
 
 import pytest
 import requests
 
 import daily_arxiv
-from daily_arxiv import find_code_link, get_authors, load_config, sort_papers
+from daily_arxiv import find_code_link, get_authors, load_config, sort_papers, update_json_file
 
 
 class TestGetAuthors:
@@ -145,3 +146,24 @@ class TestFindCodeLink:
         self._patch_get(monkeypatch, status_code=404)
         summary = "We release code at https://github.com/acme/proj)."
         assert find_code_link("9999.00000", summary=summary) == "https://github.com/acme/proj"
+
+
+class TestUpdateJsonFile:
+    def test_creates_file_on_first_run_when_missing(self, tmp_path):
+        path = tmp_path / "papers.json"
+        update_json_file(str(path), [{"NLP": {"2208.10000": "row"}}])
+        assert json.loads(path.read_text()) == {"NLP": {"2208.10000": "row"}}
+
+    def test_treats_empty_file_as_empty_dict(self, tmp_path):
+        path = tmp_path / "papers.json"
+        path.write_text("")
+        update_json_file(str(path), [{"NLP": {"2208.10000": "row"}}])
+        assert json.loads(path.read_text()) == {"NLP": {"2208.10000": "row"}}
+
+    def test_merges_into_existing_keyword(self, tmp_path):
+        path = tmp_path / "papers.json"
+        path.write_text(json.dumps({"NLP": {"2108.09112": "old"}}))
+        update_json_file(str(path), [{"NLP": {"2208.10000": "new"}}])
+        assert json.loads(path.read_text()) == {
+            "NLP": {"2108.09112": "old", "2208.10000": "new"},
+        }


### PR DESCRIPTION
## Summary
- A fresh checkout has no `docs/nlp-arxiv-daily*.json`, so the first run of `daily_arxiv.py` raised `FileNotFoundError` from `update_json_file` opening a non-existent path for reading.
- Treat a missing file as an empty dict; the subsequent write step creates it.
- Tests cover three cases: first run (file missing), existing-but-empty file, existing-with-data merge.

## Test plan
- [x] `make test` — 20 unit tests pass (3 new in `TestUpdateJsonFile`)
- [x] `make check-quality` — ruff lint + format clean
- [ ] CI green