### PR TITLE
feat(daily_arxiv): split JSON/README by calendar month with archive

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,13 @@ json_gitpage_path: "./docs/nlp-arxiv-daily-web.json"
 md_readme_path: "README.md"
 md_gitpage_path: "./docs/index.md"
 
+# archive (older months) — main JSON/README hold only the current calendar
+# month; everything older lives under these dirs as YYYY-MM.{json,md}
+archive_readme_json_dir: "./docs/archive"
+archive_readme_md_dir: "./docs/archive"
+archive_gitpage_json_dir: "./docs/archive-web"
+archive_gitpage_md_dir: "./docs/archive-web"
+
 # keywords to search
 keywords:
   "NLP":

--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -15,6 +15,7 @@ logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%
 HF_PAPERS_API = "https://huggingface.co/api/papers/"
 REQUEST_TIMEOUT = 10
 GITHUB_URL_RE = re.compile(r"https?://github\.com/[\w.-]+/[\w.-]+")
+ARXIV_KEY_RE = re.compile(r"^(\d{4})\.\d{4,5}")
 
 
 def load_config(config_file: str) -> dict:
@@ -51,6 +52,24 @@ def load_config(config_file: str) -> dict:
         config["kv"] = pretty_filters(**config)
         logging.info(f"config = {config}")
     return config
+
+
+def bucket_by_month(papers_by_keyword: dict) -> dict:
+    """
+    {keyword: {paper_key: line}} → {yymm: {keyword: {paper_key: line}}}.
+    paper_key matching ARXIV_KEY_RE (e.g. "2604.21637") is bucketed by its YYMM
+    prefix. Keys that don't match are silently dropped — defensive against any
+    legacy entries that don't follow arxiv's id format.
+    """
+    by_month: dict = {}
+    for keyword, papers in papers_by_keyword.items():
+        for key, line in papers.items():
+            m = ARXIV_KEY_RE.match(key)
+            if not m:
+                continue
+            yymm = m.group(1)
+            by_month.setdefault(yymm, {}).setdefault(keyword, {})[key] = line
+    return by_month
 
 
 def get_authors(authors, first_author=False):
@@ -137,6 +156,70 @@ def get_daily_papers(topic, query="nlp", max_results=2):
     return data, data_web
 
 
+def _yymm_to_archive_basename(yymm: str) -> str:
+    return f"20{yymm[:2]}-{yymm[2:]}"
+
+
+def _current_yymm() -> str:
+    today = datetime.date.today()
+    return f"{today.year % 100:02d}{today.month:02d}"
+
+
+def _load_papers_json(path: str, into: dict) -> None:
+    if not os.path.exists(path):
+        return
+    with open(path, "r") as f:
+        content = f.read()
+    if not content:
+        return
+    for kw, papers in json.loads(content).items():
+        into.setdefault(kw, {}).update(papers)
+
+
+def write_papers_split(
+    new_papers_list: list,
+    main_json_path: str,
+    archive_dir: str,
+    current_yymm: str | None = None,
+) -> None:
+    """
+    Re-bucket all known papers (existing main + archive + new daily) by YYMM and
+    write current month → main_json_path, older months → archive_dir/YYYY-MM.json.
+
+    Idempotent: running with new_papers_list=[] re-distributes existing data.
+    Migration is implicit — first run with a legacy "all months in main" file
+    splits it.
+    """
+    if current_yymm is None:
+        current_yymm = _current_yymm()
+
+    accumulated: dict = {}
+    _load_papers_json(main_json_path, accumulated)
+    if os.path.isdir(archive_dir):
+        for name in sorted(os.listdir(archive_dir)):
+            if name.endswith(".json"):
+                _load_papers_json(os.path.join(archive_dir, name), accumulated)
+
+    for new_papers in new_papers_list:
+        for kw, papers in new_papers.items():
+            accumulated.setdefault(kw, {}).update(papers)
+
+    by_month = bucket_by_month(accumulated)
+
+    main_dir = os.path.dirname(main_json_path)
+    if main_dir:
+        os.makedirs(main_dir, exist_ok=True)
+    main_bucket = by_month.pop(current_yymm, {})
+    with open(main_json_path, "w") as f:
+        json.dump(main_bucket, f)
+
+    os.makedirs(archive_dir, exist_ok=True)
+    for yymm, bucket in by_month.items():
+        archive_path = os.path.join(archive_dir, f"{_yymm_to_archive_basename(yymm)}.json")
+        with open(archive_path, "w") as f:
+            json.dump(bucket, f)
+
+
 def update_json_file(filename, data_dict):
     """
     daily update json file using data_dict
@@ -174,6 +257,7 @@ def json_to_md(
     show_badge=True,
     user_name="",
     repo_name="",
+    archive_index_link="",
 ):
     """
     @param filename: str
@@ -220,6 +304,9 @@ def json_to_md(
             f.write("## Updated on " + DateNow + "\n\n")
         else:
             f.write("> Updated on " + DateNow + "\n\n")
+
+        if archive_index_link:
+            f.write(f"> Older months: [archive]({archive_index_link})\n\n")
 
         # Add: table of contents
         if use_tc is True:
@@ -278,6 +365,55 @@ def json_to_md(
     logging.info(f"{task} finished")
 
 
+def render_archive_pages(
+    archive_json_dir: str,
+    archive_md_dir: str,
+    to_web: bool = False,
+    show_badge: bool = False,
+    user_name: str = "",
+    repo_name: str = "",
+) -> None:
+    """
+    Render every {YYYY-MM}.json under archive_json_dir to a sibling
+    {YYYY-MM}.md under archive_md_dir, plus an index.md listing months desc.
+    No-op when archive_json_dir doesn't exist.
+    """
+    if not os.path.isdir(archive_json_dir):
+        return
+    os.makedirs(archive_md_dir, exist_ok=True)
+
+    months = []
+    for name in sorted(os.listdir(archive_json_dir)):
+        if not name.endswith(".json"):
+            continue
+        stem = name[:-5]
+        json_to_md(
+            os.path.join(archive_json_dir, name),
+            os.path.join(archive_md_dir, f"{stem}.md"),
+            task=f"archive {stem}",
+            to_web=to_web,
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+        )
+        months.append(stem)
+
+    _write_archive_index(archive_md_dir, months, to_web=to_web)
+
+
+def _write_archive_index(archive_md_dir: str, months: list, to_web: bool = False) -> None:
+    path = os.path.join(archive_md_dir, "index.md")
+    months_desc = sorted(months, reverse=True)
+    with open(path, "w") as f:
+        if to_web:
+            f.write("---\nlayout: default\n---\n\n")
+        f.write("# Archive\n\n")
+        f.write("Older monthly snapshots.\n\n")
+        f.write("| Month |\n|---|\n")
+        for m in months_desc:
+            f.write(f"| [{m}]({m}.md) |\n")
+
+
 def demo(**config):
     data_collector = []
     data_collector_web = []
@@ -299,15 +435,25 @@ def demo(**config):
         print("\n")
     logging.info("GET daily papers end")
 
-    # 1. update README.md file
+    # 1. update README.md file (current month only; older months → docs/archive/)
     if publish_readme:
         json_file = config["json_readme_path"]
         md_file = config["md_readme_path"]
-        update_json_file(json_file, data_collector)
+        archive_json_dir = config["archive_readme_json_dir"]
+        archive_md_dir = config["archive_readme_md_dir"]
+        write_papers_split(data_collector, json_file, archive_json_dir)
         json_to_md(
             json_file,
             md_file,
             task="Update Readme",
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+            archive_index_link="docs/archive/index.md",
+        )
+        render_archive_pages(
+            archive_json_dir,
+            archive_md_dir,
             show_badge=show_badge,
             user_name=user_name,
             repo_name=repo_name,
@@ -317,11 +463,22 @@ def demo(**config):
     if publish_gitpage:
         json_file = config["json_gitpage_path"]
         md_file = config["md_gitpage_path"]
-        update_json_file(json_file, data_collector)
+        archive_json_dir = config["archive_gitpage_json_dir"]
+        archive_md_dir = config["archive_gitpage_md_dir"]
+        write_papers_split(data_collector_web, json_file, archive_json_dir)
         json_to_md(
             json_file,
             md_file,
             task="Update GitPage",
+            to_web=True,
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+            archive_index_link="archive-web/index.md",
+        )
+        render_archive_pages(
+            archive_json_dir,
+            archive_md_dir,
             to_web=True,
             show_badge=show_badge,
             user_name=user_name,

--- a/tests/test_daily_arxiv.py
+++ b/tests/test_daily_arxiv.py
@@ -1,11 +1,22 @@
 import json
+import os
 import textwrap
 
 import pytest
 import requests
 
 import daily_arxiv
-from daily_arxiv import find_code_link, get_authors, json_to_md, load_config, sort_papers, update_json_file
+from daily_arxiv import (
+    bucket_by_month,
+    find_code_link,
+    get_authors,
+    json_to_md,
+    load_config,
+    render_archive_pages,
+    sort_papers,
+    update_json_file,
+    write_papers_split,
+)
 
 
 class TestGetAuthors:
@@ -194,3 +205,183 @@ class TestJsonToMd:
         rendered = md_path.read_text()
         assert "alice/my-proj" in rendered
         assert "monologg/nlp-arxiv-daily" not in rendered
+
+    def test_archive_index_link_rendered_when_set(self, tmp_path, json_file):
+        md_path = tmp_path / "README.md"
+        json_to_md(
+            json_file,
+            str(md_path),
+            show_badge=False,
+            archive_index_link="docs/archive/index.md",
+        )
+        assert "docs/archive/index.md" in md_path.read_text()
+
+    def test_archive_index_link_omitted_when_blank(self, tmp_path, json_file):
+        md_path = tmp_path / "README.md"
+        json_to_md(json_file, str(md_path), show_badge=False)
+        assert "archive" not in md_path.read_text().lower()
+
+
+class TestBucketByMonth:
+    def test_groups_by_yymm_prefix(self):
+        papers = {
+            "NLP": {
+                "2604.00001": "row-april-26",
+                "2603.00099": "row-march-26",
+                "2208.10000": "row-aug-22",
+            },
+            "QA": {
+                "2604.99999": "row-april-26-qa",
+            },
+        }
+        out = bucket_by_month(papers)
+        assert set(out.keys()) == {"2604", "2603", "2208"}
+        assert out["2604"] == {
+            "NLP": {"2604.00001": "row-april-26"},
+            "QA": {"2604.99999": "row-april-26-qa"},
+        }
+        assert out["2603"] == {"NLP": {"2603.00099": "row-march-26"}}
+        assert out["2208"] == {"NLP": {"2208.10000": "row-aug-22"}}
+
+    def test_skips_unparseable_keys(self):
+        papers = {"NLP": {"weird-key": "x", "2604.00001": "ok"}}
+        out = bucket_by_month(papers)
+        assert "2604" in out
+        assert "weird-key" not in str(out)  # silently dropped
+        for bucket in out.values():
+            assert "weird-key" not in bucket.get("NLP", {})
+
+    def test_empty_input(self):
+        assert bucket_by_month({}) == {}
+
+    def test_skips_keyword_with_no_papers(self):
+        out = bucket_by_month({"NLP": {}, "QA": {"2604.00001": "x"}})
+        assert out == {"2604": {"QA": {"2604.00001": "x"}}}
+
+
+class TestWritePapersSplit:
+    def _setup_paths(self, tmp_path):
+        return {
+            "main": str(tmp_path / "main.json"),
+            "archive_dir": str(tmp_path / "archive"),
+        }
+
+    def test_first_run_no_existing_files(self, tmp_path):
+        paths = self._setup_paths(tmp_path)
+        write_papers_split(
+            [{"NLP": {"2604.00001": "apr-row", "2603.00099": "mar-row"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        assert json.loads(open(paths["main"]).read()) == {"NLP": {"2604.00001": "apr-row"}}
+        assert json.loads(open(f"{paths['archive_dir']}/2026-03.json").read()) == {
+            "NLP": {"2603.00099": "mar-row"},
+        }
+
+    def test_migrates_legacy_main_with_all_months(self, tmp_path):
+        """Existing 5MB main JSON containing every month gets split."""
+        paths = self._setup_paths(tmp_path)
+        # Pretend the legacy main contains 3 months of data
+        with open(paths["main"], "w") as f:
+            json.dump(
+                {
+                    "NLP": {
+                        "2604.00001": "apr",
+                        "2603.00001": "mar",
+                        "2208.00001": "aug22",
+                    }
+                },
+                f,
+            )
+        write_papers_split([], paths["main"], paths["archive_dir"], current_yymm="2604")
+
+        assert json.loads(open(paths["main"]).read()) == {"NLP": {"2604.00001": "apr"}}
+        assert json.loads(open(f"{paths['archive_dir']}/2026-03.json").read()) == {
+            "NLP": {"2603.00001": "mar"},
+        }
+        assert json.loads(open(f"{paths['archive_dir']}/2022-08.json").read()) == {
+            "NLP": {"2208.00001": "aug22"},
+        }
+
+    def test_merges_new_daily_papers_into_existing(self, tmp_path):
+        paths = self._setup_paths(tmp_path)
+        with open(paths["main"], "w") as f:
+            json.dump({"NLP": {"2604.00001": "old-apr"}}, f)
+        write_papers_split(
+            [{"NLP": {"2604.00002": "new-apr"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        assert json.loads(open(paths["main"]).read()) == {
+            "NLP": {"2604.00001": "old-apr", "2604.00002": "new-apr"},
+        }
+
+    def test_idempotent_re_bucket(self, tmp_path):
+        """Running twice with same input produces same output (no drift)."""
+        paths = self._setup_paths(tmp_path)
+        new_papers = [{"NLP": {"2604.00001": "apr", "2603.00001": "mar"}}]
+        write_papers_split(new_papers, paths["main"], paths["archive_dir"], current_yymm="2604")
+        snapshot_main = open(paths["main"]).read()
+        snapshot_archive = open(f"{paths['archive_dir']}/2026-03.json").read()
+
+        write_papers_split([], paths["main"], paths["archive_dir"], current_yymm="2604")
+        assert open(paths["main"]).read() == snapshot_main
+        assert open(f"{paths['archive_dir']}/2026-03.json").read() == snapshot_archive
+
+    def test_main_empty_when_no_current_month_papers(self, tmp_path):
+        paths = self._setup_paths(tmp_path)
+        write_papers_split(
+            [{"NLP": {"2603.00001": "mar"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",  # no April papers
+        )
+        assert json.loads(open(paths["main"]).read()) == {}
+        assert json.loads(open(f"{paths['archive_dir']}/2026-03.json").read()) == {
+            "NLP": {"2603.00001": "mar"},
+        }
+
+
+class TestRenderArchivePages:
+    def _seed_archives(self, tmp_path):
+        archive_json_dir = tmp_path / "archive-json"
+        archive_json_dir.mkdir()
+        (archive_json_dir / "2026-03.json").write_text(
+            json.dumps({"NLP": {"2603.00001": "|**2026-03-01**|**T1**|A et.al.|[id](u)|null|\n"}})
+        )
+        (archive_json_dir / "2025-12.json").write_text(
+            json.dumps({"NLP": {"2512.00099": "|**2025-12-01**|**T2**|B et.al.|[id](u)|null|\n"}})
+        )
+        return str(archive_json_dir)
+
+    def test_creates_one_md_per_archive_json(self, tmp_path):
+        archive_json_dir = self._seed_archives(tmp_path)
+        archive_md_dir = str(tmp_path / "archive-md")
+        render_archive_pages(archive_json_dir, archive_md_dir)
+        assert os.path.exists(f"{archive_md_dir}/2026-03.md")
+        assert os.path.exists(f"{archive_md_dir}/2025-12.md")
+
+    def test_archive_md_contains_month_papers(self, tmp_path):
+        archive_json_dir = self._seed_archives(tmp_path)
+        archive_md_dir = str(tmp_path / "archive-md")
+        render_archive_pages(archive_json_dir, archive_md_dir)
+        rendered = open(f"{archive_md_dir}/2026-03.md").read()
+        assert "T1" in rendered
+        assert "T2" not in rendered  # belongs to 2025-12.md
+
+    def test_index_lists_months_descending(self, tmp_path):
+        archive_json_dir = self._seed_archives(tmp_path)
+        archive_md_dir = str(tmp_path / "archive-md")
+        render_archive_pages(archive_json_dir, archive_md_dir)
+        index = open(f"{archive_md_dir}/index.md").read()
+        assert "2026-03" in index
+        assert "2025-12" in index
+        # 2026-03 must appear before 2025-12 (descending)
+        assert index.index("2026-03") < index.index("2025-12")
+
+    def test_no_op_when_archive_dir_missing(self, tmp_path):
+        archive_md_dir = str(tmp_path / "archive-md")
+        render_archive_pages(str(tmp_path / "does-not-exist"), archive_md_dir)
+        assert not os.path.exists(archive_md_dir)


### PR DESCRIPTION
## Summary

The main README and JSON have grown to ~5MB by accumulating every paper since 2007. Render times suffer and mobile barely loads the page. This PR splits accumulated data by calendar month.

**Behavior:**
- Main `README.md` / `docs/index.md` and main JSON files hold only the **current calendar month**, bucketed by the `YYMM` prefix of the arxiv id.
- Older months live under `docs/archive/{YYYY-MM}.{json,md}` (and `docs/archive-web/` for the gitpage flow), with a sibling `index.md` listing every month in descending order.
- Main README gets a one-line `> Older months: [archive](docs/archive/index.md)` footer for navigation.

**Migration is implicit and idempotent.** `write_papers_split` reads the existing main + archive JSON, merges new daily papers, re-buckets everything by month, and writes the result. The first post-merge cron run splits the legacy 5MB JSON automatically — no one-shot migration script.

## Why calendar-month rather than rolling-30-day or fixed-N
- 1:1 alignment with `docs/archive/YYYY-MM.md` structure — bucketing logic is just `paper_key[:4]`.
- Idempotent: every run re-derives the same partition. No "is March archive frozen yet?" state to track.
- Predictable to a reader: the date in the URL is the date of the papers.

## What's new
| Function | Purpose |
|---|---|
| `bucket_by_month` | `{keyword: {key: line}}` → `{yymm: {keyword: {key: line}}}` |
| `write_papers_split` | load + merge + bucket + write main / archive JSONs |
| `render_archive_pages` | render every archive JSON to a sibling MD + index.md |
| `json_to_md` (extended) | new optional `archive_index_link` param |

## Local migration dry-run

Ran the split + render flow on the existing 5MB JSON. Result:
- `README.md`: 4.5 MB → ~100 bytes (current month 2604 has no papers yet — populates on next cron run)
- `docs/archive/`: 92 monthly snapshots spanning **2007-07 → 2025-07**
- `docs/archive/index.md`: descending table of links

(Materialized files NOT committed in this PR — first cron run will produce them organically; that's also the migration step.)

## Test plan
- [x] `make test` — 37 unit tests pass (15 new across `TestBucketByMonth`, `TestWritePapersSplit`, `TestRenderArchivePages`, plus 2 in `TestJsonToMd` for archive link)
- [x] `make check-quality` — ruff lint + format clean
- [ ] CI green
- [ ] First cron run after merge: README/index.md collapse to current-month-only; `docs/archive/` and `docs/archive-web/` populated; archive index.md lists 92+ months