### PR TITLE
fix(gitpage): suppress Minima auto-nav flooded by archive pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,6 +2,8 @@ title: NLP Arxiv Daily
 description: Automatically Update NLP Papers Daily using Github Actions
 show_downloads: true
 
+header_pages: []
+
 github:
   zip_url: https://github.com/monologg/nlp-arxiv-daily
   another_url: https://github.com/monologg/nlp-arxiv-daily


### PR DESCRIPTION
## Summary
Minima v2.5.1 auto-populates the top nav with every Jekyll page in the site. After yesterday's archive split shipped ~180 `.md` files (`docs/archive/*`, `docs/archive-web/*`), the gitpage header became a giant horizontal scroll of duplicate "Updated on YYYY.MM.DD" links — one per archive month.

`header_pages: []` tells Minima to render an empty nav.

## Test plan
- [ ] After merge: confirm https://monologg.kr/nlp-arxiv-daily/ header no longer shows the archive page list

🤖 Generated with [Claude Code](https://claude.com/claude-code)