### PR TITLE
fix(gitpage): empty nav via non-existent header_pages entry

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,13 @@ title: NLP Arxiv Daily
 description: Automatically Update NLP Papers Daily using Github Actions
 show_downloads: true
 
-header_pages: []
+# Minima auto-fills the top nav with every page that has a title; jekyll-seo-tag
+# auto-derives titles for our archive months, so without an override the header
+# floods with ~180 duplicate "Updated on" links. An empty list (`[]`) is treated
+# as falsy by Liquid's `default` filter and falls back to the page list, so we
+# point at a non-existent path to render an empty nav.
+header_pages:
+  - _no_nav.md
 
 github:
   zip_url: https://github.com/monologg/nlp-arxiv-daily


### PR DESCRIPTION
## Summary
PR #20 set `header_pages: []` to suppress Minima's auto-nav, but the empty list is treated as falsy by Liquid's `default` filter in Minima v2.5.1, so it fell back to `site.pages` and the ~180 archive links re-appeared in the header. Pointing `header_pages` at a non-existent path makes Minima iterate once over a missing page (no title, no link) — net effect: empty `<nav>`.

## Test plan
- [ ] After Pages rebuild: `curl -s https://monologg.kr/nlp-arxiv-daily/ | grep -c '<a class="page-link"'` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)