### PR TITLE
refactor: split fetcher module out of core

### DIFF
--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -9,14 +9,14 @@ This module exists so that:
 
 import requests  # noqa: F401  re-exported for tests that monkeypatch daily_arxiv.requests
 
-from nlp_arxiv_daily.__main__ import main
-from nlp_arxiv_daily.core import (
+from nlp_arxiv_daily import (
     ARXIV_KEY_RE,
     GITHUB_URL_RE,
     HF_PAPERS_API,
     REQUEST_TIMEOUT,
     bucket_by_month,
     demo,
+    fetch_papers,
     find_code_link,
     get_authors,
     get_daily_papers,
@@ -27,6 +27,7 @@ from nlp_arxiv_daily.core import (
     update_json_file,
     write_papers_split,
 )
+from nlp_arxiv_daily.__main__ import main
 
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "REQUEST_TIMEOUT",
     "bucket_by_month",
     "demo",
+    "fetch_papers",
     "find_code_link",
     "get_authors",
     "get_daily_papers",

--- a/nlp_arxiv_daily/__init__.py
+++ b/nlp_arxiv_daily/__init__.py
@@ -1,12 +1,7 @@
 from nlp_arxiv_daily.core import (
     ARXIV_KEY_RE,
-    GITHUB_URL_RE,
-    HF_PAPERS_API,
-    REQUEST_TIMEOUT,
     bucket_by_month,
     demo,
-    find_code_link,
-    get_authors,
     get_daily_papers,
     json_to_md,
     load_config,
@@ -14,6 +9,14 @@ from nlp_arxiv_daily.core import (
     sort_papers,
     update_json_file,
     write_papers_split,
+)
+from nlp_arxiv_daily.fetcher import (
+    GITHUB_URL_RE,
+    HF_PAPERS_API,
+    REQUEST_TIMEOUT,
+    fetch_papers,
+    find_code_link,
+    get_authors,
 )
 from nlp_arxiv_daily.types import KeywordConfig, Paper, PapersByKeyword, PapersByMonth
 
@@ -29,6 +32,7 @@ __all__ = [
     "PapersByMonth",
     "bucket_by_month",
     "demo",
+    "fetch_papers",
     "find_code_link",
     "get_authors",
     "get_daily_papers",

--- a/nlp_arxiv_daily/core.py
+++ b/nlp_arxiv_daily/core.py
@@ -6,18 +6,14 @@ import logging
 import os
 import re
 
-import arxiv
-import requests
 import yaml
 
+from nlp_arxiv_daily.fetcher import fetch_papers
 from nlp_arxiv_daily.types import PapersByKeyword, PapersByMonth
 
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO)
 
-HF_PAPERS_API = "https://huggingface.co/api/papers/"
-REQUEST_TIMEOUT = 10
-GITHUB_URL_RE = re.compile(r"https?://github\.com/[\w.-]+/[\w.-]+")
 ARXIV_KEY_RE = re.compile(r"^(\d{4})\.\d{4,5}")
 
 
@@ -75,15 +71,6 @@ def bucket_by_month(papers_by_keyword: PapersByKeyword) -> PapersByMonth:
     return by_month
 
 
-def get_authors(authors, first_author=False):
-    output = str()
-    if first_author is False:
-        output = ", ".join(str(author) for author in authors)
-    else:
-        output = authors[0]
-    return output
-
-
 def sort_papers(papers):
     output = {}
     keys = list(papers.keys())
@@ -93,70 +80,29 @@ def sort_papers(papers):
     return output
 
 
-def find_code_link(arxiv_id: str, summary: str | None = None) -> str | None:
-    """
-    Best-effort code repo URL lookup. Returns None when nothing is found.
-    Order: HuggingFace Papers `githubRepo` → github.com URL in arxiv summary.
-    """
-    try:
-        r = requests.get(f"{HF_PAPERS_API}{arxiv_id}", timeout=REQUEST_TIMEOUT)
-        if r.status_code == 200:
-            repo = r.json().get("githubRepo")
-            if repo:
-                return repo
-    except requests.RequestException as e:
-        logging.warning(f"HF Papers lookup failed for {arxiv_id}: {e}")
-
-    if summary:
-        m = GITHUB_URL_RE.search(summary)
-        if m:
-            return m.group(0).rstrip(".,);")
-
-    return None
-
-
 def get_daily_papers(topic, query="nlp", max_results=2):
     """
-    @param topic: str
-    @param query: str
-    @return paper_with_code: dict
+    Backward-compat adapter: fetch via `fetcher.fetch_papers`, then pre-render
+    markdown rows in the legacy shape. The pre-rendering lives here only until
+    PRSL-66 splits a proper renderer module out.
     """
-    content = {}
-    content_to_web = {}
-    client = arxiv.Client()
-    search = arxiv.Search(query=query, max_results=max_results, sort_by=arxiv.SortCriterion.SubmittedDate)
+    papers = fetch_papers(query=query, max_results=max_results)
 
-    for result in client.results(search):
-        paper_id = result.get_short_id()
-        paper_title = result.title
-        paper_url = result.entry_id
-        paper_first_author = get_authors(result.authors, first_author=True)
-        update_time = result.updated.date()
-
-        logging.info(f"Time = {update_time} title = {paper_title} author = {paper_first_author}")
-
-        # eg: 2108.09112v1 -> 2108.09112
-        ver_pos = paper_id.find("v")
-        if ver_pos == -1:
-            paper_key = paper_id
-        else:
-            paper_key = paper_id[0:ver_pos]
-
-        code_link = find_code_link(paper_key, summary=result.summary)
-        code_md = f"**[link]({code_link})**" if code_link else "null"
-        content[paper_key] = "|**{}**|**{}**|{} et.al.|[{}]({})|{}|\n".format(
-            update_time, paper_title, paper_first_author, paper_id, paper_url, code_md
+    content: dict[str, str] = {}
+    content_to_web: dict[str, str] = {}
+    for p in papers:
+        code_md = f"**[link]({p.code_link})**" if p.code_link else "null"
+        content[p.paper_id] = "|**{}**|**{}**|{} et.al.|[{}]({})|{}|\n".format(
+            p.update_time, p.title, p.first_author, p.arxiv_short_id, p.paper_url, code_md
         )
         web_line = "- {}, **{}**, {} et.al., Paper: [{}]({})".format(
-            update_time, paper_title, paper_first_author, paper_url, paper_url
+            p.update_time, p.title, p.first_author, p.paper_url, p.paper_url
         )
-        if code_link:
-            web_line += f", Code: **[{code_link}]({code_link})**"
-        content_to_web[paper_key] = web_line + "\n"
+        if p.code_link:
+            web_line += f", Code: **[{p.code_link}]({p.code_link})**"
+        content_to_web[p.paper_id] = web_line + "\n"
 
-    data = {topic: content}
-    data_web = {topic: content_to_web}
-    return data, data_web
+    return {topic: content}, {topic: content_to_web}
 
 
 def _yymm_to_archive_basename(yymm: str) -> str:

--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+
+import arxiv
+import requests
+
+from nlp_arxiv_daily.types import Paper
+
+
+HF_PAPERS_API = "https://huggingface.co/api/papers/"
+REQUEST_TIMEOUT = 10
+GITHUB_URL_RE = re.compile(r"https?://github\.com/[\w.-]+/[\w.-]+")
+
+
+def get_authors(authors: Iterable, first_author: bool = False) -> str:
+    if first_author:
+        return list(authors)[0]
+    return ", ".join(str(author) for author in authors)
+
+
+def find_code_link(arxiv_id: str, summary: str | None = None) -> str | None:
+    """
+    Best-effort code repo URL lookup. Returns None when nothing is found.
+    Order: HuggingFace Papers `githubRepo` → github.com URL in arxiv summary.
+    """
+    try:
+        r = requests.get(f"{HF_PAPERS_API}{arxiv_id}", timeout=REQUEST_TIMEOUT)
+        if r.status_code == 200:
+            repo = r.json().get("githubRepo")
+            if repo:
+                return repo
+    except requests.RequestException as e:
+        logging.warning(f"HF Papers lookup failed for {arxiv_id}: {e}")
+
+    if summary:
+        m = GITHUB_URL_RE.search(summary)
+        if m:
+            return m.group(0).rstrip(".,);")
+
+    return None
+
+
+def _strip_version_suffix(short_id: str) -> str:
+    """e.g. '2108.09112v1' -> '2108.09112'."""
+    ver_pos = short_id.find("v")
+    return short_id if ver_pos == -1 else short_id[:ver_pos]
+
+
+def fetch_papers(query: str, max_results: int) -> list[Paper]:
+    """
+    Hit arxiv with `query`, sorted by submission date desc, and look up code
+    links via HF Papers / arxiv summary fallback. No markdown rendering.
+    """
+    client = arxiv.Client()
+    search = arxiv.Search(query=query, max_results=max_results, sort_by=arxiv.SortCriterion.SubmittedDate)
+
+    papers: list[Paper] = []
+    for result in client.results(search):
+        short_id = result.get_short_id()
+        paper_id = _strip_version_suffix(short_id)
+        first_author = get_authors(result.authors, first_author=True)
+        update_time = result.updated.date()
+
+        logging.info(f"Time = {update_time} title = {result.title} author = {first_author}")
+
+        papers.append(
+            Paper(
+                paper_id=paper_id,
+                title=result.title,
+                first_author=first_author,
+                update_time=update_time,
+                paper_url=result.entry_id,
+                code_link=find_code_link(paper_id, summary=result.summary),
+                arxiv_short_id=short_id,
+            )
+        )
+
+    return papers

--- a/nlp_arxiv_daily/types.py
+++ b/nlp_arxiv_daily/types.py
@@ -7,12 +7,13 @@ from typing import TypedDict
 
 @dataclass(frozen=True)
 class Paper:
-    paper_id: str
+    paper_id: str  # versionless arxiv id, e.g. "2108.09112"
     title: str
     first_author: str
     update_time: date
     paper_url: str
     code_link: str | None
+    arxiv_short_id: str = ""  # raw arxiv short id incl. version, e.g. "2108.09112v1"
 
 
 class KeywordConfig(TypedDict):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,183 @@
+import datetime
+
+import pytest
+
+from nlp_arxiv_daily import fetcher
+from nlp_arxiv_daily.fetcher import _strip_version_suffix, fetch_papers, get_authors
+from nlp_arxiv_daily.types import Paper
+
+
+class _FakeArxivResult:
+    def __init__(
+        self,
+        *,
+        short_id: str,
+        title: str = "A Title",
+        authors: list[str] | None = None,
+        updated: datetime.datetime | None = None,
+        entry_id: str = "http://arxiv.org/abs/X",
+        summary: str = "no code link here",
+    ):
+        self._short_id = short_id
+        self.title = title
+        self.authors = authors or ["Alice", "Bob"]
+        self.updated = updated or datetime.datetime(2026, 4, 22, 0, 0, 0)
+        self.entry_id = entry_id
+        self.summary = summary
+
+    def get_short_id(self):
+        return self._short_id
+
+
+class _FakeClient:
+    def __init__(self, results):
+        self._results = results
+
+    def results(self, search):  # noqa: ARG002 — mirror real API signature
+        return iter(self._results)
+
+
+def _patch_arxiv(monkeypatch, results):
+    monkeypatch.setattr(fetcher.arxiv, "Client", lambda: _FakeClient(results))
+
+    class _FakeSearch:
+        def __init__(self, query, max_results, sort_by):
+            self.query = query
+            self.max_results = max_results
+            self.sort_by = sort_by
+
+    monkeypatch.setattr(fetcher.arxiv, "Search", _FakeSearch)
+
+
+def _silence_code_link(monkeypatch):
+    monkeypatch.setattr(fetcher, "find_code_link", lambda *args, **kw: None)
+
+
+class TestStripVersionSuffix:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("2108.09112v1", "2108.09112"),
+            ("2108.09112v23", "2108.09112"),
+            ("2108.09112", "2108.09112"),  # no version
+            ("2604.21637v1", "2604.21637"),
+        ],
+    )
+    def test_strips_version(self, raw, expected):
+        assert _strip_version_suffix(raw) == expected
+
+
+class TestGetAuthors:
+    def test_first_author(self):
+        assert get_authors(["Alice", "Bob"], first_author=True) == "Alice"
+
+    def test_join_all(self):
+        assert get_authors(["Alice", "Bob"]) == "Alice, Bob"
+
+    def test_casts_objects(self):
+        class A:
+            def __str__(self):
+                return "X"
+
+        assert get_authors([A(), A()]) == "X, X"
+
+
+class TestFetchPapers:
+    def test_returns_typed_paper_list(self, monkeypatch):
+        _silence_code_link(monkeypatch)
+        results = [
+            _FakeArxivResult(
+                short_id="2604.21637v1",
+                title="Hello",
+                authors=["Alice", "Bob"],
+                updated=datetime.datetime(2026, 4, 22, 12, 0, 0),
+                entry_id="http://arxiv.org/abs/2604.21637v1",
+            )
+        ]
+        _patch_arxiv(monkeypatch, results)
+
+        papers = fetch_papers(query="NLP", max_results=2)
+
+        assert len(papers) == 1
+        p = papers[0]
+        assert isinstance(p, Paper)
+        assert p.paper_id == "2604.21637"  # version stripped
+        assert p.arxiv_short_id == "2604.21637v1"  # raw preserved
+        assert p.title == "Hello"
+        assert p.first_author == "Alice"
+        assert p.update_time == datetime.date(2026, 4, 22)
+        assert p.paper_url == "http://arxiv.org/abs/2604.21637v1"
+        assert p.code_link is None
+
+    def test_handles_empty_result_set(self, monkeypatch):
+        _silence_code_link(monkeypatch)
+        _patch_arxiv(monkeypatch, [])
+        assert fetch_papers(query="NLP", max_results=2) == []
+
+    def test_uses_versionless_id_for_code_link_lookup(self, monkeypatch):
+        seen_ids = []
+
+        def fake_find(arxiv_id, summary=None):  # noqa: ARG001
+            seen_ids.append(arxiv_id)
+            return None
+
+        monkeypatch.setattr(fetcher, "find_code_link", fake_find)
+        _patch_arxiv(monkeypatch, [_FakeArxivResult(short_id="2511.12345v3")])
+
+        fetch_papers(query="x", max_results=1)
+        # HF Papers API takes versionless ids — lookups must reflect that.
+        assert seen_ids == ["2511.12345"]
+
+    def test_propagates_code_link(self, monkeypatch):
+        monkeypatch.setattr(fetcher, "find_code_link", lambda *args, **kw: "https://github.com/foo/bar")
+        _patch_arxiv(monkeypatch, [_FakeArxivResult(short_id="2604.00001v1")])
+
+        papers = fetch_papers(query="x", max_results=1)
+        assert papers[0].code_link == "https://github.com/foo/bar"
+
+
+class TestGetDailyPapersAdapter:
+    """get_daily_papers is the legacy markdown-row adapter on top of fetch_papers."""
+
+    def test_renders_versioned_id_in_pdf_link(self, monkeypatch):
+        from nlp_arxiv_daily import get_daily_papers
+
+        _silence_code_link(monkeypatch)
+        _patch_arxiv(
+            monkeypatch,
+            [
+                _FakeArxivResult(
+                    short_id="2604.21637v2",
+                    title="T",
+                    authors=["Alice"],
+                    updated=datetime.datetime(2026, 4, 22),
+                    entry_id="http://arxiv.org/abs/2604.21637v2",
+                )
+            ],
+        )
+
+        data, data_web = get_daily_papers("NLP", query="x", max_results=1)
+        # README row keys by versionless id, but link text shows the full short id.
+        assert "2604.21637" in data["NLP"]
+        row = data["NLP"]["2604.21637"]
+        assert "[2604.21637v2](http://arxiv.org/abs/2604.21637v2)" in row
+        assert "|null|" in row  # no code link
+
+        web_row = data_web["NLP"]["2604.21637"]
+        assert web_row.startswith("- 2026-04-22, **T**, Alice et.al.")
+        assert "Code:" not in web_row  # no code link
+
+    def test_renders_code_link_when_present(self, monkeypatch):
+        from nlp_arxiv_daily import get_daily_papers
+
+        monkeypatch.setattr(fetcher, "find_code_link", lambda *args, **kw: "https://github.com/x/y")
+        _patch_arxiv(
+            monkeypatch,
+            [_FakeArxivResult(short_id="2604.00001v1")],
+        )
+
+        data, data_web = get_daily_papers("NLP", query="x", max_results=1)
+        row = data["NLP"]["2604.00001"]
+        assert "**[link](https://github.com/x/y)**" in row
+        web_row = data_web["NLP"]["2604.00001"]
+        assert "Code: **[https://github.com/x/y](https://github.com/x/y)**" in web_row


### PR DESCRIPTION
## Summary
- Introduce \`nlp_arxiv_daily/fetcher.py\` with \`fetch_papers(query, max_results) -> list[Paper]\` as the typed entry point. arxiv API + HF Papers code-link lookup live here, with no markdown rendering.
- \`get_daily_papers\` stays in \`core.py\` as a thin adapter that pre-renders legacy markdown rows on top of \`fetch_papers\`. It will go away when the renderer module lands.
- \`Paper\` gains \`arxiv_short_id\` (with version, e.g. \`2108.09112v1\`) alongside the versionless \`paper_id\`. Needed so the README row's \`[short_id](url)\` link text stays byte-for-byte identical.

## Test plan
- [x] \`make test\` — 58 tests pass (45 existing + 13 new)
- [x] 13 new tests in \`tests/test_fetcher.py\` cover: \`_strip_version_suffix\`, \`get_authors\`, \`fetch_papers\` (typed output, empty results, versionless code-link lookup, code-link propagation), and the \`get_daily_papers\` adapter (versioned-id link text, code-link rendering).
- [x] All arxiv.Client + arxiv.Search calls mocked — no network
- [x] \`make check-quality\` clean
- [ ] CI green on this PR

## Notes
- Why keep \`get_daily_papers\`: the cron flow (\`demo()\`) still calls it, and the legacy markdown shape is easier to refactor in one focused PR (PRSL-66 / renderer split).
- \`find_code_link\` continues to use \`requests.get\` against the \`requests\` module, so the existing \`monkeypatch.setattr(daily_arxiv.requests, ...)\` tests keep working unchanged (the shim still imports \`requests\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)