### PR TITLE
refactor: split storage module out of core

### DIFF
--- a/nlp_arxiv_daily/__init__.py
+++ b/nlp_arxiv_daily/__init__.py
@@ -1,14 +1,10 @@
 from nlp_arxiv_daily.core import (
-    ARXIV_KEY_RE,
-    bucket_by_month,
     demo,
     get_daily_papers,
     json_to_md,
     load_config,
     render_archive_pages,
     sort_papers,
-    update_json_file,
-    write_papers_split,
 )
 from nlp_arxiv_daily.fetcher import (
     GITHUB_URL_RE,
@@ -17,6 +13,12 @@ from nlp_arxiv_daily.fetcher import (
     fetch_papers,
     find_code_link,
     get_authors,
+)
+from nlp_arxiv_daily.storage import (
+    ARXIV_KEY_RE,
+    bucket_by_month,
+    update_json_file,
+    write_papers_split,
 )
 from nlp_arxiv_daily.types import KeywordConfig, Paper, PapersByKeyword, PapersByMonth
 

--- a/nlp_arxiv_daily/core.py
+++ b/nlp_arxiv_daily/core.py
@@ -9,12 +9,10 @@ import re
 import yaml
 
 from nlp_arxiv_daily.fetcher import fetch_papers
-from nlp_arxiv_daily.types import PapersByKeyword, PapersByMonth
+from nlp_arxiv_daily.storage import write_papers_split
 
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO)
-
-ARXIV_KEY_RE = re.compile(r"^(\d{4})\.\d{4,5}")
 
 
 def load_config(config_file: str) -> dict:
@@ -53,24 +51,6 @@ def load_config(config_file: str) -> dict:
     return config
 
 
-def bucket_by_month(papers_by_keyword: PapersByKeyword) -> PapersByMonth:
-    """
-    {keyword: {paper_key: line}} → {yymm: {keyword: {paper_key: line}}}.
-    paper_key matching ARXIV_KEY_RE (e.g. "2604.21637") is bucketed by its YYMM
-    prefix. Keys that don't match are silently dropped — defensive against any
-    legacy entries that don't follow arxiv's id format.
-    """
-    by_month: PapersByMonth = {}
-    for keyword, papers in papers_by_keyword.items():
-        for key, line in papers.items():
-            m = ARXIV_KEY_RE.match(key)
-            if not m:
-                continue
-            yymm = m.group(1)
-            by_month.setdefault(yymm, {}).setdefault(keyword, {})[key] = line
-    return by_month
-
-
 def sort_papers(papers):
     output = {}
     keys = list(papers.keys())
@@ -103,97 +83,6 @@ def get_daily_papers(topic, query="nlp", max_results=2):
         content_to_web[p.paper_id] = web_line + "\n"
 
     return {topic: content}, {topic: content_to_web}
-
-
-def _yymm_to_archive_basename(yymm: str) -> str:
-    return f"20{yymm[:2]}-{yymm[2:]}"
-
-
-def _current_yymm() -> str:
-    today = datetime.date.today()
-    return f"{today.year % 100:02d}{today.month:02d}"
-
-
-def _load_papers_json(path: str, into: dict) -> None:
-    if not os.path.exists(path):
-        return
-    with open(path, "r") as f:
-        content = f.read()
-    if not content:
-        return
-    for kw, papers in json.loads(content).items():
-        into.setdefault(kw, {}).update(papers)
-
-
-def write_papers_split(
-    new_papers_list: list[PapersByKeyword],
-    main_json_path: str,
-    archive_dir: str,
-    current_yymm: str | None = None,
-) -> None:
-    """
-    Re-bucket all known papers (existing main + archive + new daily) by YYMM and
-    write current month → main_json_path, older months → archive_dir/YYYY-MM.json.
-
-    Idempotent: running with new_papers_list=[] re-distributes existing data.
-    Migration is implicit — first run with a legacy "all months in main" file
-    splits it.
-    """
-    if current_yymm is None:
-        current_yymm = _current_yymm()
-
-    accumulated: PapersByKeyword = {}
-    _load_papers_json(main_json_path, accumulated)
-    if os.path.isdir(archive_dir):
-        for name in sorted(os.listdir(archive_dir)):
-            if name.endswith(".json"):
-                _load_papers_json(os.path.join(archive_dir, name), accumulated)
-
-    for new_papers in new_papers_list:
-        for kw, papers in new_papers.items():
-            accumulated.setdefault(kw, {}).update(papers)
-
-    by_month = bucket_by_month(accumulated)
-
-    main_dir = os.path.dirname(main_json_path)
-    if main_dir:
-        os.makedirs(main_dir, exist_ok=True)
-    main_bucket = by_month.pop(current_yymm, {})
-    with open(main_json_path, "w") as f:
-        json.dump(main_bucket, f)
-
-    os.makedirs(archive_dir, exist_ok=True)
-    for yymm, bucket in by_month.items():
-        archive_path = os.path.join(archive_dir, f"{_yymm_to_archive_basename(yymm)}.json")
-        with open(archive_path, "w") as f:
-            json.dump(bucket, f)
-
-
-def update_json_file(filename, data_dict):
-    """
-    daily update json file using data_dict
-    """
-    if os.path.exists(filename):
-        with open(filename, "r") as f:
-            content = f.read()
-        m = json.loads(content) if content else {}
-    else:
-        m = {}
-
-    json_data = m.copy()
-
-    # update papers in each keywords
-    for data in data_dict:
-        for keyword in data.keys():
-            papers = data[keyword]
-
-            if keyword in json_data.keys():
-                json_data[keyword].update(papers)
-            else:
-                json_data[keyword] = papers
-
-    with open(filename, "w") as f:
-        json.dump(json_data, f)
 
 
 def json_to_md(

--- a/nlp_arxiv_daily/storage.py
+++ b/nlp_arxiv_daily/storage.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import re
+
+from nlp_arxiv_daily.types import PapersByKeyword, PapersByMonth
+
+
+ARXIV_KEY_RE = re.compile(r"^(\d{4})\.\d{4,5}")
+
+
+def bucket_by_month(papers_by_keyword: PapersByKeyword) -> PapersByMonth:
+    """
+    {keyword: {paper_key: line}} → {yymm: {keyword: {paper_key: line}}}.
+    paper_key matching ARXIV_KEY_RE (e.g. "2604.21637") is bucketed by its YYMM
+    prefix. Keys that don't match are silently dropped — defensive against any
+    legacy entries that don't follow arxiv's id format.
+    """
+    by_month: PapersByMonth = {}
+    for keyword, papers in papers_by_keyword.items():
+        for key, line in papers.items():
+            m = ARXIV_KEY_RE.match(key)
+            if not m:
+                continue
+            yymm = m.group(1)
+            by_month.setdefault(yymm, {}).setdefault(keyword, {})[key] = line
+    return by_month
+
+
+def _yymm_to_archive_basename(yymm: str) -> str:
+    return f"20{yymm[:2]}-{yymm[2:]}"
+
+
+def _current_yymm() -> str:
+    today = datetime.date.today()
+    return f"{today.year % 100:02d}{today.month:02d}"
+
+
+def _load_papers_json(path: str, into: dict) -> None:
+    if not os.path.exists(path):
+        return
+    with open(path, "r") as f:
+        content = f.read()
+    if not content:
+        return
+    for kw, papers in json.loads(content).items():
+        into.setdefault(kw, {}).update(papers)
+
+
+def write_papers_split(
+    new_papers_list: list[PapersByKeyword],
+    main_json_path: str,
+    archive_dir: str,
+    current_yymm: str | None = None,
+) -> None:
+    """
+    Re-bucket all known papers (existing main + archive + new daily) by YYMM and
+    write current month → main_json_path, older months → archive_dir/YYYY-MM.json.
+
+    Idempotent: running with new_papers_list=[] re-distributes existing data.
+    Migration is implicit — first run with a legacy "all months in main" file
+    splits it.
+    """
+    if current_yymm is None:
+        current_yymm = _current_yymm()
+
+    accumulated: PapersByKeyword = {}
+    _load_papers_json(main_json_path, accumulated)
+    if os.path.isdir(archive_dir):
+        for name in sorted(os.listdir(archive_dir)):
+            if name.endswith(".json"):
+                _load_papers_json(os.path.join(archive_dir, name), accumulated)
+
+    for new_papers in new_papers_list:
+        for kw, papers in new_papers.items():
+            accumulated.setdefault(kw, {}).update(papers)
+
+    by_month = bucket_by_month(accumulated)
+
+    main_dir = os.path.dirname(main_json_path)
+    if main_dir:
+        os.makedirs(main_dir, exist_ok=True)
+    main_bucket = by_month.pop(current_yymm, {})
+    with open(main_json_path, "w") as f:
+        json.dump(main_bucket, f)
+
+    os.makedirs(archive_dir, exist_ok=True)
+    for yymm, bucket in by_month.items():
+        archive_path = os.path.join(archive_dir, f"{_yymm_to_archive_basename(yymm)}.json")
+        with open(archive_path, "w") as f:
+            json.dump(bucket, f)
+
+
+def update_json_file(filename, data_dict):
+    """
+    daily update json file using data_dict
+    """
+    if os.path.exists(filename):
+        with open(filename, "r") as f:
+            content = f.read()
+        m = json.loads(content) if content else {}
+    else:
+        m = {}
+
+    json_data = m.copy()
+
+    # update papers in each keywords
+    for data in data_dict:
+        for keyword in data.keys():
+            papers = data[keyword]
+
+            if keyword in json_data.keys():
+                json_data[keyword].update(papers)
+            else:
+                json_data[keyword] = papers
+
+    with open(filename, "w") as f:
+        json.dump(json_data, f)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,169 @@
+import json
+
+from nlp_arxiv_daily.storage import (
+    _current_yymm,
+    _yymm_to_archive_basename,
+    bucket_by_month,
+    write_papers_split,
+)
+
+
+class TestYymmHelpers:
+    def test_yymm_to_archive_basename(self):
+        assert _yymm_to_archive_basename("2604") == "2026-04"
+        assert _yymm_to_archive_basename("9912") == "2099-12"
+        assert _yymm_to_archive_basename("0001") == "2000-01"
+
+    def test_current_yymm_format(self):
+        v = _current_yymm()
+        assert len(v) == 4
+        assert v.isdigit()
+
+
+class TestBucketByMonthEdgeCases:
+    """Complementary to TestBucketByMonth in test_daily_arxiv.py."""
+
+    def test_two_keywords_same_paper_id_kept_separately(self):
+        # Same paper indexed under two keywords stays under both buckets/keywords
+        papers = {
+            "NLP": {"2604.00001": "row-nlp"},
+            "QA": {"2604.00001": "row-qa"},
+        }
+        out = bucket_by_month(papers)
+        assert out["2604"]["NLP"]["2604.00001"] == "row-nlp"
+        assert out["2604"]["QA"]["2604.00001"] == "row-qa"
+
+    def test_5digit_paper_id_bucketed(self):
+        # arxiv supports both 4- and 5-digit paper numbers; both are valid
+        papers = {"NLP": {"2604.12345": "row"}}
+        out = bucket_by_month(papers)
+        assert out == {"2604": {"NLP": {"2604.12345": "row"}}}
+
+
+class TestWritePapersSplitRoundTrip:
+    def _seed(self, tmp_path):
+        return {
+            "main": str(tmp_path / "main.json"),
+            "archive_dir": str(tmp_path / "archive"),
+        }
+
+    def test_multi_month_byte_stable_across_reruns(self, tmp_path):
+        """Re-running with empty new_papers_list must not drift any file."""
+        paths = self._seed(tmp_path)
+        write_papers_split(
+            [
+                {
+                    "NLP": {
+                        "2604.00001": "apr",
+                        "2603.00099": "mar",
+                        "2208.10000": "aug22",
+                    },
+                    "QA": {
+                        "2604.00099": "apr-qa",
+                        "2208.99999": "aug22-qa",
+                    },
+                }
+            ],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+
+        # Snapshot every file
+        all_paths = [
+            paths["main"],
+            f"{paths['archive_dir']}/2026-03.json",
+            f"{paths['archive_dir']}/2022-08.json",
+        ]
+        snapshots = {p: open(p).read() for p in all_paths}
+
+        # Re-run idempotently
+        write_papers_split([], paths["main"], paths["archive_dir"], current_yymm="2604")
+
+        for p in all_paths:
+            assert open(p).read() == snapshots[p], f"{p} drifted across reruns"
+
+    def test_late_arriving_paper_merges_into_old_archive(self, tmp_path):
+        """A paper from an archived month must merge into the right archive file."""
+        paths = self._seed(tmp_path)
+        # Seed: April current, March archive
+        write_papers_split(
+            [{"NLP": {"2604.00001": "apr-old", "2603.00001": "mar-old"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        # Daily fetch returns a March paper that wasn't in the archive
+        write_papers_split(
+            [{"NLP": {"2603.00002": "mar-new"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        march = json.loads(open(f"{paths['archive_dir']}/2026-03.json").read())
+        assert march == {"NLP": {"2603.00001": "mar-old", "2603.00002": "mar-new"}}
+        # April main is untouched by the late-arriving March paper
+        april = json.loads(open(paths["main"]).read())
+        assert april == {"NLP": {"2604.00001": "apr-old"}}
+
+    def test_archive_file_unchanged_when_no_new_paper_in_that_month(self, tmp_path):
+        """An archive file's content must be identical after a re-run that
+        only adds papers to the current month."""
+        paths = self._seed(tmp_path)
+        # Seed two months
+        write_papers_split(
+            [{"NLP": {"2604.00001": "apr", "2603.00001": "mar"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        march_before = open(f"{paths['archive_dir']}/2026-03.json").read()
+
+        # Add only a new April paper
+        write_papers_split(
+            [{"NLP": {"2604.00002": "apr-new"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        march_after = open(f"{paths['archive_dir']}/2026-03.json").read()
+        assert march_before == march_after
+
+    def test_keyword_added_later_does_not_lose_old_archive_data(self, tmp_path):
+        """When a NEW keyword first appears, existing archive files for OTHER
+        keywords must not be wiped — re-bucketing reads the whole archive."""
+        paths = self._seed(tmp_path)
+        write_papers_split(
+            [{"NLP": {"2603.00001": "mar"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        # Add a new keyword for current month only
+        write_papers_split(
+            [{"QA": {"2604.00001": "apr-qa"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        march = json.loads(open(f"{paths['archive_dir']}/2026-03.json").read())
+        # NLP March data must still be there
+        assert march == {"NLP": {"2603.00001": "mar"}}
+
+    def test_overwrite_in_same_month_takes_latest_value(self, tmp_path):
+        """Same paper id submitted twice — the second value wins (revision)."""
+        paths = self._seed(tmp_path)
+        write_papers_split(
+            [{"NLP": {"2604.00001": "v1"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        write_papers_split(
+            [{"NLP": {"2604.00001": "v2"}}],
+            paths["main"],
+            paths["archive_dir"],
+            current_yymm="2604",
+        )
+        main = json.loads(open(paths["main"]).read())
+        assert main == {"NLP": {"2604.00001": "v2"}}


### PR DESCRIPTION
## Summary
- Move JSON load/save + YYMM bucketing into \`nlp_arxiv_daily/storage.py\`. Verbatim move — no behavior change.
- \`core.py\` now imports \`write_papers_split\` from \`storage\` and only owns renderer + orchestration (next two PRs split those further).
- Re-exports preserved at package root and through the \`daily_arxiv\` shim, so the cron flow and existing imports keep working unchanged.

## Test plan
- [x] \`make test\` — 67 tests pass (58 existing + 9 new)
- [x] 9 new tests in \`tests/test_storage.py\` cover:
  - Round-trip byte-stability across multiple months (re-running with no new papers must not drift any file)
  - Late-arriving paper from an old month merges into the right archive
  - Archive files stay byte-equal when only the current month changes
  - Adding a brand-new keyword doesn't wipe existing-keyword archives
  - Same-id overwrite (revision) semantics — second write wins
  - YYMM helpers + bucket edge cases (5-digit ids, same id under multiple keywords)
- [x] \`make check-quality\` clean
- [ ] CI green on this PR

## Notes
- Existing \`TestWritePapersSplit\` / \`TestBucketByMonth\` / \`TestUpdateJsonFile\` / \`TestRenderArchivePages\` in \`tests/test_daily_arxiv.py\` keep importing through the \`daily_arxiv\` shim and continue to pass — verifying the public API contract is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)