### PR TITLE
refactor: argparse subcommands + workflow wiring

### DIFF
--- a/.github/workflows/nlp-arxiv-daily.yml
+++ b/.github/workflows/nlp-arxiv-daily.yml
@@ -30,7 +30,7 @@ jobs:
         run: make set-dev
 
       - name: Run daily arxiv
-        run: uv run --frozen python daily_arxiv.py
+        run: uv run --frozen python -m nlp_arxiv_daily run
 
       - name: Push new nlp-arxiv-daily.md
         uses: github-actions-x/commit@v2.9

--- a/nlp_arxiv_daily/__init__.py
+++ b/nlp_arxiv_daily/__init__.py
@@ -1,3 +1,4 @@
+from nlp_arxiv_daily.cli import cmd_fetch, cmd_render, cmd_run
 from nlp_arxiv_daily.core import demo, get_daily_papers, load_config
 from nlp_arxiv_daily.fetcher import (
     GITHUB_URL_RE,
@@ -32,6 +33,9 @@ __all__ = [
     "PapersByKeyword",
     "PapersByMonth",
     "bucket_by_month",
+    "cmd_fetch",
+    "cmd_render",
+    "cmd_run",
     "demo",
     "fetch_papers",
     "find_code_link",

--- a/nlp_arxiv_daily/__main__.py
+++ b/nlp_arxiv_daily/__main__.py
@@ -1,15 +1,7 @@
-import argparse
+import sys
 
-from nlp_arxiv_daily.core import demo, load_config
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config_path", type=str, default="config.yaml", help="configuration file path")
-    args = parser.parse_args()
-    config = load_config(args.config_path)
-    demo(**config)
+from nlp_arxiv_daily.cli import main
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -1,0 +1,131 @@
+"""CLI subcommand dispatch for the nlp_arxiv_daily pipeline.
+
+Three subcommands:
+- `fetch`  — query arxiv per keyword, persist current/archive JSON splits.
+- `render` — read the persisted JSON, write README/gitpage/archive markdown.
+- `run`    — fetch then render (this is what the cron workflow calls).
+
+JSON is the boundary between fetch and render, so the two subcommands can
+also be run independently — useful for backfills and golden-output testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from nlp_arxiv_daily.core import get_daily_papers, load_config
+from nlp_arxiv_daily.renderer import json_to_md, render_archive_pages
+from nlp_arxiv_daily.storage import write_papers_split
+
+
+def cmd_fetch(config: dict) -> None:
+    """Query arxiv for every keyword in `config["kv"]`, persist JSON splits."""
+    keywords = config["kv"]
+    max_results = config["max_results"]
+
+    data_collector = []
+    data_collector_web = []
+
+    logging.info("GET daily papers begin")
+    for topic, keyword in keywords.items():
+        logging.info(f"Keyword: {topic}")
+        data, data_web = get_daily_papers(topic, query=keyword, max_results=max_results)
+        data_collector.append(data)
+        data_collector_web.append(data_web)
+        logging.info("")
+    logging.info("GET daily papers end")
+
+    if config["publish_readme"]:
+        write_papers_split(
+            data_collector,
+            config["json_readme_path"],
+            config["archive_readme_json_dir"],
+        )
+    if config["publish_gitpage"]:
+        write_papers_split(
+            data_collector_web,
+            config["json_gitpage_path"],
+            config["archive_gitpage_json_dir"],
+        )
+
+
+def cmd_render(config: dict) -> None:
+    """Read the persisted JSON splits, render README/gitpage/archive markdown."""
+    show_badge = config["show_badge"]
+    user_name = config["user_name"]
+    repo_name = config["repo_name"]
+
+    if config["publish_readme"]:
+        json_to_md(
+            config["json_readme_path"],
+            config["md_readme_path"],
+            task="Update Readme",
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+            archive_index_link="docs/archive/index.md",
+        )
+        render_archive_pages(
+            config["archive_readme_json_dir"],
+            config["archive_readme_md_dir"],
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+        )
+
+    if config["publish_gitpage"]:
+        json_to_md(
+            config["json_gitpage_path"],
+            config["md_gitpage_path"],
+            task="Update GitPage",
+            to_web=True,
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+            archive_index_link="archive-web/index.md",
+        )
+        render_archive_pages(
+            config["archive_gitpage_json_dir"],
+            config["archive_gitpage_md_dir"],
+            to_web=True,
+            show_badge=show_badge,
+            user_name=user_name,
+            repo_name=repo_name,
+        )
+
+
+def cmd_run(config: dict) -> None:
+    """Full pipeline: fetch then render. The cron workflow calls this."""
+    cmd_fetch(config)
+    cmd_render(config)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="nlp_arxiv_daily")
+    parser.add_argument(
+        "--config_path",
+        type=str,
+        default="config.yaml",
+        help="configuration file path",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("run", help="fetch then render (default)")
+    sub.add_parser("fetch", help="fetch arxiv + persist JSON splits")
+    sub.add_parser("render", help="render persisted JSON to markdown")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = load_config(args.config_path)
+    # Resolve handler at call time so tests can monkeypatch cmd_* on this module.
+    command = args.command or "run"
+    handler = {"run": cmd_run, "fetch": cmd_fetch, "render": cmd_render}[command]
+    handler(config)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nlp_arxiv_daily/core.py
+++ b/nlp_arxiv_daily/core.py
@@ -5,8 +5,6 @@ import logging
 import yaml
 
 from nlp_arxiv_daily.fetcher import fetch_papers
-from nlp_arxiv_daily.renderer import json_to_md, render_archive_pages
-from nlp_arxiv_daily.storage import write_papers_split
 
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO)
@@ -51,8 +49,8 @@ def load_config(config_file: str) -> dict:
 def get_daily_papers(topic, query="nlp", max_results=2):
     """
     Backward-compat adapter: fetch via `fetcher.fetch_papers`, then pre-render
-    markdown rows in the legacy shape. Kept here because `demo()` still feeds
-    its output back through `write_papers_split`.
+    markdown rows in the legacy shape. Used by `cli.cmd_fetch` to keep the
+    JSON files in the existing format the renderer expects.
     """
     papers = fetch_papers(query=query, max_results=max_results)
 
@@ -73,73 +71,8 @@ def get_daily_papers(topic, query="nlp", max_results=2):
     return {topic: content}, {topic: content_to_web}
 
 
-def demo(**config):
-    data_collector = []
-    data_collector_web = []
+def demo(**config) -> None:
+    """Backward-compat alias for `cli.cmd_run`. Prefer the CLI entrypoint."""
+    from nlp_arxiv_daily.cli import cmd_run
 
-    keywords = config["kv"]
-    max_results = config["max_results"]
-    publish_readme = config["publish_readme"]
-    publish_gitpage = config["publish_gitpage"]
-    show_badge = config["show_badge"]
-    user_name = config["user_name"]
-    repo_name = config["repo_name"]
-
-    logging.info("GET daily papers begin")
-    for topic, keyword in keywords.items():
-        logging.info(f"Keyword: {topic}")
-        data, data_web = get_daily_papers(topic, query=keyword, max_results=max_results)
-        data_collector.append(data)
-        data_collector_web.append(data_web)
-        print("\n")
-    logging.info("GET daily papers end")
-
-    # 1. update README.md file (current month only; older months → docs/archive/)
-    if publish_readme:
-        json_file = config["json_readme_path"]
-        md_file = config["md_readme_path"]
-        archive_json_dir = config["archive_readme_json_dir"]
-        archive_md_dir = config["archive_readme_md_dir"]
-        write_papers_split(data_collector, json_file, archive_json_dir)
-        json_to_md(
-            json_file,
-            md_file,
-            task="Update Readme",
-            show_badge=show_badge,
-            user_name=user_name,
-            repo_name=repo_name,
-            archive_index_link="docs/archive/index.md",
-        )
-        render_archive_pages(
-            archive_json_dir,
-            archive_md_dir,
-            show_badge=show_badge,
-            user_name=user_name,
-            repo_name=repo_name,
-        )
-
-    # 2. update docs/index.md file (to gitpage)
-    if publish_gitpage:
-        json_file = config["json_gitpage_path"]
-        md_file = config["md_gitpage_path"]
-        archive_json_dir = config["archive_gitpage_json_dir"]
-        archive_md_dir = config["archive_gitpage_md_dir"]
-        write_papers_split(data_collector_web, json_file, archive_json_dir)
-        json_to_md(
-            json_file,
-            md_file,
-            task="Update GitPage",
-            to_web=True,
-            show_badge=show_badge,
-            user_name=user_name,
-            repo_name=repo_name,
-            archive_index_link="archive-web/index.md",
-        )
-        render_archive_pages(
-            archive_json_dir,
-            archive_md_dir,
-            to_web=True,
-            show_badge=show_badge,
-            user_name=user_name,
-            repo_name=repo_name,
-        )
+    cmd_run(config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,136 @@
+"""CLI dispatch tests.
+
+The hard guarantee: `render`-only must NOT make network calls (it only reads
+persisted JSON), and `fetch`-only must NOT touch markdown. The cron path
+(`run`) calls both in order.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from nlp_arxiv_daily import cli
+
+
+@pytest.fixture
+def fake_config_file(tmp_path):
+    json_dir = tmp_path / "docs"
+    json_dir.mkdir()
+    archive_dir = json_dir / "archive"
+    archive_web_dir = json_dir / "archive-web"
+    archive_dir.mkdir()
+    archive_web_dir.mkdir()
+    # Empty JSON files so render() has something to read
+    (json_dir / "main.json").write_text("{}")
+    (json_dir / "main-web.json").write_text("{}")
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            f"""
+            user_name: "alice"
+            repo_name: "my-repo"
+            show_authors: true
+            show_links: true
+            show_badge: false
+            max_results: 1
+            publish_readme: true
+            publish_gitpage: true
+            json_readme_path: "{json_dir / "main.json"}"
+            json_gitpage_path: "{json_dir / "main-web.json"}"
+            md_readme_path: "{tmp_path / "README.md"}"
+            md_gitpage_path: "{json_dir / "index.md"}"
+            archive_readme_json_dir: "{archive_dir}"
+            archive_readme_md_dir: "{archive_dir}"
+            archive_gitpage_json_dir: "{archive_web_dir}"
+            archive_gitpage_md_dir: "{archive_web_dir}"
+            keywords:
+              "NLP":
+                filters: ["NLP"]
+            """
+        ).strip()
+    )
+    return str(cfg)
+
+
+class TestArgparser:
+    def test_no_subcommand_defaults_to_run(self):
+        ns = cli.build_parser().parse_args([])
+        assert ns.command is None  # main() coerces to "run"
+
+    def test_subcommands_recognized(self):
+        for sub in ("run", "fetch", "render"):
+            ns = cli.build_parser().parse_args([sub])
+            assert ns.command == sub
+
+    def test_config_path_default(self):
+        ns = cli.build_parser().parse_args([])
+        assert ns.config_path == "config.yaml"
+
+    def test_config_path_override(self):
+        ns = cli.build_parser().parse_args(["--config_path", "x.yaml", "fetch"])
+        assert ns.config_path == "x.yaml"
+
+
+class TestDispatch:
+    def test_main_no_subcommand_dispatches_run(self, monkeypatch, fake_config_file):
+        called = []
+        monkeypatch.setattr(cli, "cmd_run", lambda config: called.append(("run", config)))
+        cli.main(["--config_path", fake_config_file])
+        assert len(called) == 1
+        assert called[0][0] == "run"
+
+    def test_main_render_dispatches_render(self, monkeypatch, fake_config_file):
+        called = []
+        monkeypatch.setattr(cli, "cmd_render", lambda config: called.append(("render", config)))
+        cli.main(["--config_path", fake_config_file, "render"])
+        assert called and called[0][0] == "render"
+
+    def test_main_fetch_dispatches_fetch(self, monkeypatch, fake_config_file):
+        called = []
+        monkeypatch.setattr(cli, "cmd_fetch", lambda config: called.append(("fetch", config)))
+        cli.main(["--config_path", fake_config_file, "fetch"])
+        assert called and called[0][0] == "fetch"
+
+
+class TestCommandIsolation:
+    """Behavioral isolation: render MUST NOT fetch, fetch MUST NOT render."""
+
+    def test_render_does_not_fetch(self, monkeypatch, fake_config_file):
+        def boom(*a, **kw):
+            raise AssertionError("render must not call fetch_papers / get_daily_papers")
+
+        monkeypatch.setattr("nlp_arxiv_daily.fetcher.fetch_papers", boom)
+        monkeypatch.setattr("nlp_arxiv_daily.core.get_daily_papers", boom)
+        # render against an empty JSON config — should produce empty markdown only
+        cli.main(["--config_path", fake_config_file, "render"])
+
+    def test_fetch_does_not_render(self, monkeypatch, fake_config_file):
+        def boom(*a, **kw):
+            raise AssertionError("fetch must not call json_to_md / render_archive_pages")
+
+        monkeypatch.setattr("nlp_arxiv_daily.cli.json_to_md", boom)
+        monkeypatch.setattr("nlp_arxiv_daily.cli.render_archive_pages", boom)
+
+        # Mock fetch_papers so no network
+        from nlp_arxiv_daily import fetcher
+
+        monkeypatch.setattr(fetcher.arxiv, "Client", lambda: type("X", (), {"results": lambda self, s: iter([])})())
+
+        class _FakeSearch:
+            def __init__(self, *a, **kw):
+                pass
+
+        monkeypatch.setattr(fetcher.arxiv, "Search", _FakeSearch)
+        cli.main(["--config_path", fake_config_file, "fetch"])
+
+
+class TestCmdRunInvocation:
+    def test_run_calls_fetch_then_render_in_order(self, monkeypatch, fake_config_file):
+        order = []
+        monkeypatch.setattr(cli, "cmd_fetch", lambda config: order.append("fetch"))
+        monkeypatch.setattr(cli, "cmd_render", lambda config: order.append("render"))
+        cli.main(["--config_path", fake_config_file, "run"])
+        assert order == ["fetch", "render"]


### PR DESCRIPTION
## Summary
- Introduce \`fetch\`, \`render\`, \`run\` subcommands. JSON files are the boundary between fetch and render, so the two halves can run independently — useful for backfills, golden-output testing, and one-off re-renders without hitting arxiv.
- Default subcommand is \`run\` (= fetch + render), so legacy invocations like \`python daily_arxiv.py\` and \`python -m nlp_arxiv_daily\` still execute the full pipeline.
- Workflow: cron now calls \`python -m nlp_arxiv_daily run\` instead of \`python daily_arxiv.py\`. The shim still works for any external caller.
- Drop the lone \`print("\\n")\` in the fetch loop in favor of \`logging.info("")\`.

## Test plan
- [x] \`make test\` — 101 tests pass (91 existing + 10 new)
- [x] argparse: defaults + explicit subcommands + \`--config_path\` override
- [x] Dispatch: monkeypatched \`cmd_run\` / \`cmd_fetch\` / \`cmd_render\` fire on the matching argv (required rebuilding the handler dict inside \`main()\` so module-level patches are visible)
- [x] **Isolation**: \`render\`-only must NOT call \`fetch_papers\` / \`get_daily_papers\`; \`fetch\`-only must NOT call \`json_to_md\` / \`render_archive_pages\`. Tests assert via \`AssertionError\`-raising stubs.
- [x] Order: \`cmd_run\` calls fetch then render.
- [x] \`make check-quality\` clean
- [x] **Manual smoke**: \`uv run python -m nlp_arxiv_daily render\` against the live config — regenerated README + 90-odd archive .md files; the only diff vs HEAD was the "Updated on" date (yesterday → today). Reverted the regen output from this branch since cron will write it naturally.
- [ ] CI green

## Notes
- \`demo(**config)\` is kept in \`core.py\` as a backward-compat alias that defers to \`cmd_run\` — protects any external caller still importing it.
- \`backfill\` slot intentionally left empty in the parser; PRSL-69 (the July-2025+ data backfill) will plug into \`cli.py\` as a fourth subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)