### PR TITLE
fix(cli): backfill ignores config max_results

### DIFF
--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -19,7 +19,7 @@ import sys
 from collections.abc import Iterator
 
 from nlp_arxiv_daily.core import get_daily_papers, load_config, papers_to_legacy_rows
-from nlp_arxiv_daily.fetcher import fetch_papers_in_range
+from nlp_arxiv_daily.fetcher import BACKFILL_DEFAULT_MAX_RESULTS, fetch_papers_in_range
 from nlp_arxiv_daily.renderer import json_to_md, render_archive_pages
 from nlp_arxiv_daily.storage import write_papers_split
 
@@ -127,14 +127,23 @@ def _iter_month_ranges(start: datetime.date, end: datetime.date) -> Iterator[tup
         cur = next_first
 
 
-def cmd_backfill(config: dict, *, start: datetime.date, end: datetime.date) -> None:
+def cmd_backfill(
+    config: dict,
+    *,
+    start: datetime.date,
+    end: datetime.date,
+    max_results: int = BACKFILL_DEFAULT_MAX_RESULTS,
+) -> None:
     """Fetch every (keyword × month) in [start, end] and merge into the archive.
 
     Idempotent — the underlying `write_papers_split` re-buckets all known
     papers, so re-running over an already-populated range is safe.
+
+    `max_results` controls per (keyword × month) cap. Defaults to the backfill-
+    appropriate ceiling (NOT `config["max_results"]`, which is the daily-fetch
+    cap of ~10 — far too low for a months-wide recovery).
     """
     keywords = config["kv"]
-    max_results = config["max_results"]
 
     data_collector = []
     data_collector_web = []
@@ -201,6 +210,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="end month (inclusive), YYYY-MM (default: current month)",
     )
+    backfill.add_argument(
+        "--max-results",
+        type=int,
+        default=BACKFILL_DEFAULT_MAX_RESULTS,
+        help=f"max results per (keyword × month) query (default: {BACKFILL_DEFAULT_MAX_RESULTS})",
+    )
     return parser
 
 
@@ -216,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if command == "backfill":
         end = args.end if args.end is not None else _current_month_first()
-        cmd_backfill(config, start=args.start, end=end)
+        cmd_backfill(config, start=args.start, end=end, max_results=args.max_results)
         return 0
 
     # Resolve handler at call time so tests can monkeypatch cmd_* on this module.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,9 +178,10 @@ class TestBackfillDispatch:
     def test_backfill_with_explicit_end_invokes_cmd_backfill(self, monkeypatch, fake_config_file):
         captured = {}
 
-        def fake(config, *, start, end):
+        def fake(config, *, start, end, max_results):
             captured["start"] = start
             captured["end"] = end
+            captured["max_results"] = max_results
 
         monkeypatch.setattr(cli, "cmd_backfill", fake)
         cli.main(
@@ -196,18 +197,42 @@ class TestBackfillDispatch:
         )
         assert captured["start"] == datetime.date(2025, 8, 1)
         assert captured["end"] == datetime.date(2026, 3, 1)
+        # Backfill default must NOT inherit config["max_results"] (which is the
+        # daily-fetch top-N cap of ~10) — it ignores config and uses the
+        # backfill-appropriate ceiling from fetcher.BACKFILL_DEFAULT_MAX_RESULTS.
+        assert captured["max_results"] >= 1000
 
     def test_backfill_default_end_is_current_month(self, monkeypatch, fake_config_file):
         captured = {}
         monkeypatch.setattr(
             cli,
             "cmd_backfill",
-            lambda config, *, start, end: captured.setdefault("end", end),
+            lambda config, *, start, end, max_results: captured.setdefault("end", end),
         )
         # Pin "today" so the test is deterministic.
         monkeypatch.setattr(cli, "_current_month_first", lambda: datetime.date(2026, 4, 1))
         cli.main(["--config_path", fake_config_file, "backfill", "--start", "2025-08"])
         assert captured["end"] == datetime.date(2026, 4, 1)
+
+    def test_backfill_max_results_override(self, monkeypatch, fake_config_file):
+        captured = {}
+        monkeypatch.setattr(
+            cli,
+            "cmd_backfill",
+            lambda config, *, start, end, max_results: captured.setdefault("max_results", max_results),
+        )
+        cli.main(
+            [
+                "--config_path",
+                fake_config_file,
+                "backfill",
+                "--start",
+                "2025-08",
+                "--max-results",
+                "50",
+            ]
+        )
+        assert captured["max_results"] == 50
 
     def test_backfill_requires_start(self, fake_config_file):
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Bug
\`cmd_backfill\` was reading \`config[\"max_results\"]\` (the daily-fetch top-N cap, typically **10**) and using it as the per (keyword × month) ceiling. Result: the live backfill of 2025-08 → 2026-03 returned ~10 papers per keyword per month, producing 8–30 KB archive files where the expected size is 100–200 KB.

## Fix
- \`cmd_backfill\` defaults \`max_results\` to \`fetcher.BACKFILL_DEFAULT_MAX_RESULTS\` (2000), independent of config.
- New \`--max-results\` flag on the backfill subparser for explicit overrides.
- Tests added:
  - asserts the default value is \`>= 1000\` (regression guard against re-introducing the config inheritance)
  - asserts \`--max-results 50\` threads through dispatch unchanged

## Test plan
- [x] 122 tests pass (121 + 1 new override test); coverage 96.6%
- [x] \`make check-quality\` clean
- [ ] CI green
- [ ] After merge: re-run backfill against live config → expect archive file sizes in the 100–200 KB range

🤖 Generated with [Claude Code](https://claude.com/claude-code)