### PR TITLE
fix(backfill): tolerate arxiv 429 + skip-on-failure resilience

### DIFF
--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -151,19 +151,32 @@ def cmd_backfill(
     months = list(_iter_month_ranges(start, end))
     logging.info(f"BACKFILL begin: {start.isoformat()} → {end.isoformat()} ({len(months)} months)")
 
+    failed_queries: list[str] = []
     for month_start, month_end in months:
         logging.info(f"=== {month_start.strftime('%Y-%m')} ===")
         for topic, keyword in keywords.items():
             logging.info(f"Keyword: {topic}")
-            papers = fetch_papers_in_range(
-                query=keyword,
-                start=month_start,
-                end=month_end,
-                max_results=max_results,
-            )
+            try:
+                papers = fetch_papers_in_range(
+                    query=keyword,
+                    start=month_start,
+                    end=month_end,
+                    max_results=max_results,
+                )
+            except Exception as e:
+                # One bad keyword × month must not kill the rest of the backfill.
+                # Persisted JSON splits are write-on-success in storage; partial
+                # progress is still safe to commit.
+                tag = f"{month_start.strftime('%Y-%m')}/{topic}"
+                logging.warning(f"BACKFILL skip {tag}: {e}")
+                failed_queries.append(tag)
+                continue
             data, data_web = papers_to_legacy_rows(papers, topic)
             data_collector.append(data)
             data_collector_web.append(data_web)
+
+    if failed_queries:
+        logging.warning(f"BACKFILL completed with {len(failed_queries)} skipped queries: " + ", ".join(failed_queries))
 
     logging.info("BACKFILL fetch end — persisting JSON splits")
     if config["publish_readme"]:

--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -14,9 +14,12 @@ from nlp_arxiv_daily.types import Paper
 HF_PAPERS_API = "https://huggingface.co/api/papers/"
 REQUEST_TIMEOUT = 10
 GITHUB_URL_RE = re.compile(r"https?://github\.com/[\w.-]+/[\w.-]+")
-# arxiv API publishes a 3s minimum between requests; keep this for backfill
-# loops that fire many keyword × month queries back-to-back.
-BACKFILL_RATE_LIMIT_SECONDS = 3
+# arxiv API publishes a 3s minimum between requests, but bulk backfill
+# pagination triggers 429s in practice — use a more conservative gap.
+BACKFILL_RATE_LIMIT_SECONDS = 5
+# arxiv.Client default is 3 retries; bump it so transient 429 storms during
+# a multi-page query don't kill the whole backfill.
+BACKFILL_NUM_RETRIES = 10
 # Default upper bound per (keyword, month) backfill query — busy keywords
 # can return hundreds of arxiv submissions in a single month.
 BACKFILL_DEFAULT_MAX_RESULTS = 2000
@@ -110,6 +113,9 @@ def fetch_papers_in_range(
     )
     composite = f"({query}) AND {range_clause}"
 
-    client = arxiv.Client(delay_seconds=BACKFILL_RATE_LIMIT_SECONDS)
+    client = arxiv.Client(
+        delay_seconds=BACKFILL_RATE_LIMIT_SECONDS,
+        num_retries=BACKFILL_NUM_RETRIES,
+    )
     search = arxiv.Search(query=composite, max_results=max_results, sort_by=arxiv.SortCriterion.SubmittedDate)
     return [_result_to_paper(r) for r in client.results(search)]


### PR DESCRIPTION
## Bug
Live backfill of 2025-08 → 2026-03 hit HTTP 429 on the 3rd page of a busy query (Question Answering, August 2025). \`arxiv.Client\` retried 3 times (its default) and gave up, killing the whole backfill before any JSON was written.

\`\`\`
arxiv.HTTPError: Page request resulted in HTTP 429 (...search_query=(QAOR\"Question+Answering\")...&start=200&max_results=100)
\`\`\`

## Fix
- **\`BACKFILL_RATE_LIMIT_SECONDS\`**: \`3 → 5\`. The 3s baseline is arxiv's published minimum but bulk pagination needs more headroom.
- **\`BACKFILL_NUM_RETRIES = 10\`**: new constant, passed to \`arxiv.Client\`. Lets the lib weather transient 429 storms across multiple page fetches.
- **\`cmd_backfill\` resilience**: each \`(keyword × month)\` query is wrapped in try/except. Failed queries are logged + recorded; loop continues. Final summary lists skipped queries so a partial backfill is auditable. Persisted JSON splits are write-on-success, so partial progress survives.

## Test plan
- [x] 122 tests pass; coverage 95.4%
- [x] \`make check-quality\` clean
- [ ] CI green
- [ ] After merge: re-run \`backfill --start 2025-08 --end 2026-03\` against live config

## Notes
With \`delay_seconds=5\`, the worst case for a single 2000-result query (20 pages) is ~95 seconds. Across 88 queries that's still well under an hour, and most queries return far fewer than 2000 results so they finish in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)