### PR TITLE
feat(astro): paper-list UI — Header/Footer/PaperCard/Section/TOC

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -1,0 +1,10 @@
+---
+const today = new Date().toISOString().slice(0, 10);
+---
+
+<footer class="border-t border-[--color-muted]/20 mt-16">
+  <div class="max-w-3xl mx-auto px-6 py-6 flex items-center justify-between text-sm text-[--color-muted]">
+    <span>Daily-refreshed NLP arxiv digest.</span>
+    <span>Built {today}</span>
+  </div>
+</footer>

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -1,0 +1,39 @@
+---
+import { withBase } from "../utils/url.ts";
+
+interface Props {
+  current?: "home" | "archive";
+}
+
+const { current = "home" } = Astro.props;
+---
+
+<header class="border-b border-[--color-muted]/20">
+  <div class="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+    <a class="font-semibold tracking-tight" href={withBase("/")}>
+      NLP Arxiv Daily
+    </a>
+    <nav class="flex items-center gap-5 text-sm">
+      <a
+        class:list={[
+          "hover:text-[--color-accent]",
+          current === "home" && "font-medium",
+        ]}
+        href={withBase("/")}
+      >
+        Latest
+      </a>
+      <a
+        class:list={[
+          "hover:text-[--color-accent]",
+          current === "archive" && "font-medium",
+        ]}
+        href={withBase("/archive/")}
+      >
+        Archive
+      </a>
+      {/* Search button slot — Pagefind wires up in PRSL-74 */}
+      {/* Theme toggle slot — lands in PRSL-73 */}
+    </nav>
+  </div>
+</header>

--- a/web/src/components/KeywordSection.astro
+++ b/web/src/components/KeywordSection.astro
@@ -1,0 +1,23 @@
+---
+import PaperCard from "./PaperCard.astro";
+import { sortPapersDesc } from "../utils/paperRow.ts";
+
+interface Props {
+  keyword: string;
+  papers: Record<string, string>;
+}
+
+const { keyword, papers } = Astro.props;
+const slug = keyword.toLowerCase().replace(/\s+/g, "-");
+const ordered = sortPapersDesc(papers);
+---
+
+<section id={slug} class="mb-12 scroll-mt-20">
+  <header class="flex items-baseline justify-between mb-3 pb-2 border-b border-[--color-muted]/30">
+    <h2 class="text-2xl font-semibold">{keyword}</h2>
+    <span class="text-[--color-muted] text-sm">{ordered.length} paper{ordered.length === 1 ? "" : "s"}</span>
+  </header>
+  {ordered.map(([paperId, row]) => (
+    <PaperCard paperId={paperId} row={row} />
+  ))}
+</section>

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -1,0 +1,54 @@
+---
+import { parsePaperRow } from "../utils/paperRow.ts";
+
+interface Props {
+  paperId: string;
+  row: string;
+}
+
+const { paperId, row } = Astro.props;
+const parsed = parsePaperRow(row);
+---
+
+{parsed ? (
+  <article class="py-3 border-b border-[--color-muted]/15 last:border-b-0">
+    <div class="flex items-baseline justify-between gap-3 mb-1">
+      <h3 class="font-medium leading-snug">
+        <a
+          class="hover:text-[--color-accent] hover:underline"
+          href={parsed.paperUrl}
+          target="_blank"
+          rel="noopener"
+        >
+          {parsed.title}
+        </a>
+      </h3>
+      <time class="text-[--color-muted] text-xs whitespace-nowrap shrink-0">{parsed.date}</time>
+    </div>
+    <div class="flex items-center gap-3 text-sm text-[--color-muted]">
+      <span>{parsed.firstAuthor} et al.</span>
+      <a
+        class="text-[--color-accent] hover:underline"
+        href={parsed.paperUrl}
+        target="_blank"
+        rel="noopener"
+      >
+        arxiv:{paperId}
+      </a>
+      {parsed.codeLink && (
+        <a
+          class="text-[--color-accent] hover:underline"
+          href={parsed.codeLink}
+          target="_blank"
+          rel="noopener"
+        >
+          code
+        </a>
+      )}
+    </div>
+  </article>
+) : (
+  <article class="py-3 border-b border-[--color-muted]/15 last:border-b-0 text-[--color-muted] text-sm">
+    <span>{paperId}</span> — unparseable row
+  </article>
+)}

--- a/web/src/components/TableOfContents.astro
+++ b/web/src/components/TableOfContents.astro
@@ -1,0 +1,26 @@
+---
+interface Props {
+  keywords: Array<[string, Record<string, string>]>;
+}
+
+const { keywords } = Astro.props;
+---
+
+<nav class="mb-10 p-4 rounded border border-[--color-muted]/20 bg-[--color-muted]/5">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-[--color-muted] mb-2">
+    Table of Contents
+  </h2>
+  <ul class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+    {keywords.map(([keyword, papers]) => {
+      const slug = keyword.toLowerCase().replace(/\s+/g, "-");
+      return (
+        <li>
+          <a class="text-[--color-accent] hover:underline" href={`#${slug}`}>
+            {keyword}
+          </a>
+          <span class="text-[--color-muted]"> ({Object.keys(papers).length})</span>
+        </li>
+      );
+    })}
+  </ul>
+</nav>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -1,12 +1,19 @@
 ---
 import "../styles/global.css";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
 
 interface Props {
   title: string;
   description?: string;
+  current?: "home" | "archive";
 }
 
-const { title, description = "Daily-updated NLP arxiv paper digest" } = Astro.props;
+const {
+  title,
+  description = "Daily-updated NLP arxiv paper digest",
+  current = "home",
+} = Astro.props;
 ---
 
 <!doctype html>
@@ -17,7 +24,11 @@ const { title, description = "Daily-updated NLP arxiv paper digest" } = Astro.pr
     <meta name="description" content={description} />
     <title>{title}</title>
   </head>
-  <body class="bg-[--color-bg] text-[--color-fg] font-sans min-h-screen antialiased">
-    <slot />
+  <body class="bg-[--color-bg] text-[--color-fg] font-sans min-h-screen flex flex-col antialiased">
+    <Header current={current} />
+    <div class="flex-1">
+      <slot />
+    </div>
+    <Footer />
   </body>
 </html>

--- a/web/src/pages/archive/[month].astro
+++ b/web/src/pages/archive/[month].astro
@@ -1,5 +1,8 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import KeywordSection from "../../components/KeywordSection.astro";
+import TableOfContents from "../../components/TableOfContents.astro";
+import { withBase } from "../../utils/url.ts";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
@@ -12,36 +15,42 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const data = entry.data;
-const keywords = Object.entries(data).filter(([, papers]) => Object.keys(papers).length > 0);
-const totalPapers = keywords.reduce((sum, [, papers]) => sum + Object.keys(papers).length, 0);
+const keywords = Object.entries(data).filter(
+  ([, papers]) => Object.keys(papers).length > 0,
+);
+const totalPapers = keywords.reduce(
+  (sum, [, papers]) => sum + Object.keys(papers).length,
+  0,
+);
 ---
 
-<Layout title={`${entry.id} — NLP Arxiv Daily`}>
-  <main class="max-w-3xl mx-auto px-6 py-12">
+<Layout
+  title={`${entry.id} — NLP Arxiv Daily`}
+  description={`NLP arxiv papers from ${entry.id}`}
+  current="archive"
+>
+  <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
-      <p class="text-[--color-muted] text-sm mb-2">
-        <a class="text-[--color-accent] hover:underline" href="/nlp-arxiv-daily/archive/">← all archives</a>
+      <p class="text-sm text-[--color-muted] mb-2">
+        <a class="hover:text-[--color-accent] hover:underline" href={withBase("/archive/")}>
+          ← all archives
+        </a>
       </p>
       <h1 class="text-4xl font-bold mb-2">{entry.id}</h1>
-      <p class="text-[--color-muted]">
+      <p class="text-[--color-muted] text-sm">
         {totalPapers} papers across {keywords.length} keywords.
       </p>
     </header>
 
-    <section>
-      <h2 class="text-xl font-semibold mb-4">Keywords</h2>
-      <ul class="space-y-1">
+    {keywords.length > 0 ? (
+      <>
+        <TableOfContents keywords={keywords} />
         {keywords.map(([keyword, papers]) => (
-          <li class="flex justify-between border-b border-[--color-muted]/20 py-2">
-            <span>{keyword}</span>
-            <span class="text-[--color-muted] text-sm">{Object.keys(papers).length}</span>
-          </li>
+          <KeywordSection keyword={keyword} papers={papers} />
         ))}
-      </ul>
-    </section>
-
-    <p class="mt-12 text-[--color-muted] text-sm">
-      Real paper rendering lands in PRSL-72.
-    </p>
+      </>
+    ) : (
+      <p class="text-[--color-muted]">No papers in this snapshot.</p>
+    )}
   </main>
 </Layout>

--- a/web/src/pages/archive/index.astro
+++ b/web/src/pages/archive/index.astro
@@ -1,28 +1,46 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import { withBase } from "../../utils/url.ts";
 import { getCollection } from "astro:content";
 
-const months = (await getCollection("archive")).map((entry) => entry.id).sort().reverse();
+const entries = await getCollection("archive");
+// Sort newest first.
+const months = entries.map((e) => e.id).sort().reverse();
+
+// Group by year so the long list is browsable on a dense screen.
+const byYear = new Map<string, string[]>();
+for (const month of months) {
+  const year = month.slice(0, 4);
+  if (!byYear.has(year)) byYear.set(year, []);
+  byYear.get(year)!.push(month);
+}
 ---
 
-<Layout title="Archive — NLP Arxiv Daily">
-  <main class="max-w-3xl mx-auto px-6 py-12">
+<Layout title="Archive — NLP Arxiv Daily" current="archive">
+  <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Archive</h1>
-      <p class="text-[--color-muted]">
-        {months.length} monthly snapshots.
-        <a class="text-[--color-accent] underline" href="/nlp-arxiv-daily/">Back to current month</a>.
+      <p class="text-[--color-muted] text-sm">
+        {months.length} monthly snapshots since {months[months.length - 1]}.
       </p>
     </header>
 
-    <ul class="space-y-1">
-      {months.map((month) => (
-        <li class="border-b border-[--color-muted]/20 py-2">
-          <a class="text-[--color-accent] hover:underline" href={`/nlp-arxiv-daily/archive/${month}/`}>
-            {month}
-          </a>
-        </li>
-      ))}
-    </ul>
+    {Array.from(byYear.entries()).map(([year, items]) => (
+      <section class="mb-8">
+        <h2 class="text-xl font-semibold mb-2">{year}</h2>
+        <ul class="flex flex-wrap gap-2">
+          {items.map((month) => (
+            <li>
+              <a
+                class="inline-block px-3 py-1 rounded border border-[--color-muted]/30 hover:border-[--color-accent] hover:text-[--color-accent] text-sm"
+                href={withBase(`/archive/${month}/`)}
+              >
+                {month}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
   </main>
 </Layout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,41 +1,41 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import KeywordSection from "../components/KeywordSection.astro";
+import TableOfContents from "../components/TableOfContents.astro";
 import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../content.config.ts";
 
-// Validate the current-month JSON at build time using the same Zod schema
-// as the archive collection. Catches malformed Python output before deploy.
 const data = paperBucketSchema.parse(currentPapers);
-const keywords = Object.entries(data).filter(([, papers]) => Object.keys(papers).length > 0);
-const totalPapers = keywords.reduce((sum, [, papers]) => sum + Object.keys(papers).length, 0);
+const keywords = Object.entries(data).filter(
+  ([, papers]) => Object.keys(papers).length > 0,
+);
+const totalPapers = keywords.reduce(
+  (sum, [, papers]) => sum + Object.keys(papers).length,
+  0,
+);
+const today = new Date().toISOString().slice(0, 10);
 ---
 
-<Layout title="NLP Arxiv Daily">
-  <main class="max-w-3xl mx-auto px-6 py-12">
+<Layout title="NLP Arxiv Daily" current="home">
+  <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
-      <h1 class="text-4xl font-bold mb-2">NLP Arxiv Daily</h1>
-      <p class="text-[--color-muted]">
+      <h1 class="text-4xl font-bold mb-2">Updated {today}</h1>
+      <p class="text-[--color-muted] text-sm">
         {totalPapers} papers across {keywords.length} keywords this month.
-        Older months: <a class="text-[--color-accent] underline" href="/nlp-arxiv-daily/archive/">archive</a>.
       </p>
     </header>
 
-    <section>
-      <h2 class="text-xl font-semibold mb-4">Keywords</h2>
-      <ul class="space-y-1">
+    {keywords.length > 0 ? (
+      <>
+        <TableOfContents keywords={keywords} />
         {keywords.map(([keyword, papers]) => (
-          <li class="flex justify-between border-b border-[--color-muted]/20 py-2">
-            <a class="text-[--color-accent] hover:underline" href={`#${keyword.toLowerCase().replace(/\s+/g, "-")}`}>
-              {keyword}
-            </a>
-            <span class="text-[--color-muted] text-sm">{Object.keys(papers).length}</span>
-          </li>
+          <KeywordSection keyword={keyword} papers={papers} />
         ))}
-      </ul>
-    </section>
-
-    <p class="mt-12 text-[--color-muted] text-sm">
-      Real paper rendering lands in PRSL-72.
-    </p>
+      </>
+    ) : (
+      <p class="text-[--color-muted]">
+        No papers published yet this month — the cron picks them up daily.
+      </p>
+    )}
   </main>
 </Layout>

--- a/web/src/utils/paperRow.ts
+++ b/web/src/utils/paperRow.ts
@@ -1,0 +1,48 @@
+/**
+ * Parse a legacy markdown paper row into structured fields.
+ *
+ * The Python pipeline (PRSL-66 renderer + cli) emits rows shaped like:
+ *
+ *   "- 2026-04-22, **Title**, Author et.al., Paper: [url](url)\n"
+ *
+ * or with a code link appended:
+ *
+ *   "- 2026-04-22, **Title**, Author et.al., Paper: [url](url), Code: **[ghurl](ghurl)**\n"
+ *
+ * This parser is the read-side counterpart to `core.papers_to_legacy_rows`
+ * on the Python side. The legacy markdown format is the JSON contract for
+ * now; later tickets may flip to structured Paper JSON, at which point this
+ * util goes away.
+ */
+export interface ParsedPaper {
+  date: string; // ISO YYYY-MM-DD
+  title: string;
+  firstAuthor: string;
+  paperUrl: string;
+  codeLink: string | null;
+}
+
+const ROW_RE =
+  // Anchor on the leading "- ", capture date, title, author, paper url, and optional code link.
+  /^-\s+(\d{4}-\d{2}-\d{2}),\s+\*\*(.+?)\*\*,\s+(.+?)\s+et\.al\.,\s+Paper:\s+\[(.+?)\]\(.+?\)(?:,\s+Code:\s+\*\*\[(.+?)\]\(.+?\)\*\*)?\s*$/;
+
+export function parsePaperRow(row: string): ParsedPaper | null {
+  const match = row.trim().match(ROW_RE);
+  if (!match) return null;
+  const [, date, title, firstAuthor, paperUrl, codeLink] = match;
+  return {
+    date,
+    title,
+    firstAuthor,
+    paperUrl,
+    codeLink: codeLink ?? null,
+  };
+}
+
+/**
+ * Sort papers within a keyword section: newest paper id first (which mirrors
+ * what the Python renderer does, since arxiv ids are monotonic by submission).
+ */
+export function sortPapersDesc(papers: Record<string, string>): Array<[string, string]> {
+  return Object.entries(papers).sort(([a], [b]) => (a < b ? 1 : a > b ? -1 : 0));
+}

--- a/web/src/utils/url.ts
+++ b/web/src/utils/url.ts
@@ -1,0 +1,11 @@
+/**
+ * Prefix an absolute path with `import.meta.env.BASE_URL` so links work
+ * both at the dev root (`/`) and the prod subpath (`/nlp-arxiv-daily/`).
+ *
+ * Always pass paths starting with `/`; the helper trims the trailing slash
+ * of the base before concatenating to avoid `//` artifacts.
+ */
+export function withBase(path: string): string {
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Summary
Replaces the placeholder index + month pages with proper paper-list UI. Parses the legacy markdown row format on the read side so the JSON contract emitted by the Python pipeline doesn't need to change in this PR.

## What's in
- \`web/src/utils/paperRow.ts\`: parses \`"- {date}, **{title}**, {author} et.al., Paper: [url](url)[, Code: **[ghurl](ghurl)**]"\` into a structured object. Returns null on unparseable input so the renderer degrades gracefully.
- \`web/src/utils/url.ts\`: \`withBase()\` helper so links resolve correctly at both \`/\` (dev) and \`/nlp-arxiv-daily/\` (prod).
- \`web/src/components/PaperCard.astro\`: title link + arxiv id + author + optional code badge.
- \`web/src/components/KeywordSection.astro\`: anchor heading, paper count, papers sorted desc by id (matches Python output).
- \`web/src/components/TableOfContents.astro\`: pill list of keyword anchors.
- \`web/src/components/Header.astro\`: top nav (Latest / Archive) with placeholder slots for search (PRSL-74) and theme toggle (PRSL-73).
- \`web/src/components/Footer.astro\`: brief credit + build date.
- \`web/src/layouts/Layout.astro\`: composes Header + slot + Footer.
- \`index.astro\`, \`archive/[month].astro\`, \`archive/index.astro\` rewritten to use the components. Archive index groups months by year as pill chips.

## Test plan
- [x] \`pnpm build\` → 102 pages in 2.4s
- [x] 2026-02 archive page renders **100 \`<article>\` elements** with **zero** "unparseable row" fallbacks
- [x] Mobile-responsive widths down to 320px (truncation + flex-wrap)
- [ ] CI green
- [ ] (manual) Visual review via \`pnpm preview\` after CI lands

## Notes
- Theme toggle + dark mode = PRSL-73
- Pagefind search wires into the Header search slot in PRSL-74
- Keyword filter (URL state) on the index = PRSL-75
- This PR keeps the Python row format as-is. A future cleanup may flip the JSON contract to structured Paper objects, at which point \`paperRow.ts\` goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)