### PR TITLE
feat(astro): client-side full-text search via Pagefind

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
+import pagefind from "astro-pagefind";
 import tailwindcss from "@tailwindcss/vite";
 
 const isProd = process.env.NODE_ENV === "production";
@@ -11,8 +12,12 @@ const isProd = process.env.NODE_ENV === "production";
 export default defineConfig({
   site: isProd ? "https://monologg.kr" : undefined,
   base: isProd ? "/nlp-arxiv-daily" : undefined,
+  // Pagefind indexes "directory" outputs by default (`/foo/index.html`); the
+  // integration's docs note `format: "file"` works too, but we stick with the
+  // default since that's what GitHub Pages serves cleanest.
   output: "static",
-  integrations: [sitemap()],
+  // pagefind() must run AFTER sitemap so it indexes the final dist tree.
+  integrations: [sitemap(), pagefind()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,8 @@
     "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^6.1.9",
+    "astro-pagefind": "^1.8.6",
+    "pagefind": "^1.5.2",
     "tailwindcss": "^4.2.4"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       astro:
         specifier: ^6.1.9
         version: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)
+      astro-pagefind:
+        specifier: ^1.8.6
+        version: 1.8.6(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3))
+      pagefind:
+        specifier: ^1.5.2
+        version: 1.5.2
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -401,6 +407,47 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/default-ui@1.5.2':
+    resolution: {integrity: sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==}
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -719,6 +766,11 @@ packages:
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
+  astro-pagefind@1.8.6:
+    resolution: {integrity: sha512-pofDcWMgA3qLQX9gSJ1mc3NSJDv6o1PDs68MrtdupxMFIlAFT2yckFSiOoaab2stSDmKyX/wVaTObyj5FuBulA==}
+    peerDependencies:
+      astro: ^2.0.4 || ^3 || ^4 || ^5 || ^6
 
   astro@6.1.9:
     resolution: {integrity: sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==}
@@ -1285,6 +1337,10 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+    hasBin: true
+
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
@@ -1394,6 +1450,10 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -1445,6 +1505,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1941,6 +2005,31 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@pagefind/darwin-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/darwin-x64@1.5.2':
+    optional: true
+
+  '@pagefind/default-ui@1.5.2': {}
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
+    optional: true
+
+  '@polka/url@1.0.0-next.29': {}
+
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
       '@types/estree': 1.0.8
@@ -2176,6 +2265,13 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  astro-pagefind@1.8.6(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)):
+    dependencies:
+      '@pagefind/default-ui': 1.5.2
+      astro: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)
+      pagefind: 1.5.2
+      sirv: 3.0.2
 
   astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3):
     dependencies:
@@ -3015,6 +3111,16 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pagefind@1.5.2:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
+
   parse-latin@7.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -3229,6 +3335,12 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -3275,6 +3387,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  totalist@3.0.1: {}
 
   trim-lines@3.0.1: {}
 

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -3,7 +3,7 @@ import { withBase } from "../utils/url.ts";
 import ThemeToggle from "./ThemeToggle.astro";
 
 interface Props {
-  current?: "home" | "archive";
+  current?: "home" | "archive" | "search";
 }
 
 const { current = "home" } = Astro.props;
@@ -33,7 +33,29 @@ const { current = "home" } = Astro.props;
       >
         Archive
       </a>
-      {/* Search button slot — Pagefind wires up in PRSL-74 */}
+      <a
+        class:list={[
+          "inline-flex items-center justify-center w-9 h-9 rounded border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors",
+          current === "search" && "border-[--color-accent] text-[--color-accent]",
+        ]}
+        href={withBase("/search/")}
+        aria-label="Search"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="w-4 h-4"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+      </a>
       <ThemeToggle />
     </nav>
   </div>

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -11,9 +11,12 @@ const parsed = parsePaperRow(row);
 ---
 
 {parsed ? (
-  <article class="py-3 border-b border-[--color-muted]/15 last:border-b-0">
+  <article
+    class="py-3 border-b border-[--color-border] last:border-b-0"
+    data-pagefind-body
+  >
     <div class="flex items-baseline justify-between gap-3 mb-1">
-      <h3 class="font-medium leading-snug">
+      <h3 class="font-medium leading-snug" data-pagefind-meta="title">
         <a
           class="hover:text-[--color-accent] hover:underline"
           href={parsed.paperUrl}
@@ -23,15 +26,18 @@ const parsed = parsePaperRow(row);
           {parsed.title}
         </a>
       </h3>
-      <time class="text-[--color-muted] text-xs whitespace-nowrap shrink-0">{parsed.date}</time>
+      <time class="text-[--color-muted] text-xs whitespace-nowrap shrink-0" data-pagefind-meta="date">
+        {parsed.date}
+      </time>
     </div>
     <div class="flex items-center gap-3 text-sm text-[--color-muted]">
-      <span>{parsed.firstAuthor} et al.</span>
+      <span data-pagefind-meta="author">{parsed.firstAuthor} et al.</span>
       <a
         class="text-[--color-accent] hover:underline"
         href={parsed.paperUrl}
         target="_blank"
         rel="noopener"
+        data-pagefind-ignore
       >
         arxiv:{paperId}
       </a>
@@ -41,6 +47,7 @@ const parsed = parsePaperRow(row);
           href={parsed.codeLink}
           target="_blank"
           rel="noopener"
+          data-pagefind-ignore
         >
           code
         </a>

--- a/web/src/pages/search.astro
+++ b/web/src/pages/search.astro
@@ -1,0 +1,75 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Search from "astro-pagefind/components/Search";
+---
+
+<Layout title="Search — NLP Arxiv Daily" current="search">
+  <main class="max-w-3xl mx-auto px-6 py-10">
+    <header class="mb-6">
+      <h1 class="text-4xl font-bold mb-2">Search</h1>
+      <p class="text-[--color-muted] text-sm">
+        Full-text across every paper in the archive.
+      </p>
+    </header>
+
+    <Search
+      id="search"
+      className="pagefind-ui"
+      uiOptions={{
+        showImages: false,
+        showSubResults: true,
+        autofocus: true,
+        debounceTimeoutMs: 150,
+      }}
+    />
+  </main>
+
+  <script>
+    // Keep the URL ?q= in sync with the search input — makes results
+    // shareable via plain link copy/paste.
+    const sync = () => {
+      const input = document.querySelector<HTMLInputElement>(
+        "#search input[type='text']",
+      );
+      if (!input) return;
+
+      const url = new URL(window.location.href);
+      const initial = url.searchParams.get("q");
+      if (initial) {
+        input.value = initial;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+
+      input.addEventListener("input", (e) => {
+        const v = (e.target as HTMLInputElement).value;
+        const u = new URL(window.location.href);
+        if (v) {
+          u.searchParams.set("q", v);
+        } else {
+          u.searchParams.delete("q");
+        }
+        window.history.replaceState({}, "", u);
+      });
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", sync);
+    } else {
+      sync();
+    }
+  </script>
+
+  <style is:global>
+    /* Match Pagefind UI to our token palette so it inherits dark mode. */
+    :root {
+      --pagefind-ui-scale: 0.9;
+      --pagefind-ui-primary: var(--color-accent);
+      --pagefind-ui-text: var(--color-fg);
+      --pagefind-ui-background: var(--color-bg);
+      --pagefind-ui-border: var(--color-border);
+      --pagefind-ui-tag: var(--color-surface);
+      --pagefind-ui-border-radius: 6px;
+      --pagefind-ui-font: var(--font-sans);
+    }
+  </style>
+</Layout>


### PR DESCRIPTION
## Summary
Build-time full-text search across every paper, served as static files alongside the site. Lazy-loads JS on input focus so visitors who never search don't pay for the bundle.

## What's in
- **\`astro-pagefind\` integration** appended after \`sitemap()\` so it indexes the final dist tree.
- **\`/search\` route** with the integration's \`<Search />\` component. \`?q=\` URL state synced both directions: initial load reads it, typing writes back via \`history.replaceState\` — results are shareable via plain link copy/paste.
- **Header search button** → \`/search/\`, with active-state styling when on that page.
- **\`PaperCard\` indexing markers**: \`data-pagefind-body\` on the article, \`data-pagefind-meta\` on title/date/author, \`data-pagefind-ignore\` on internal anchors so they don't pollute excerpts.
- **Inline \`<style is:global>\`** maps Pagefind UI's CSS vars to our token palette so the search UI inherits dark mode automatically.

## Test plan
- [x] \`pnpm build\` → 103 pages, Pagefind indexed all of them
- [x] \`dist/pagefind/\` total **812K**, \`pagefind-ui.js\` 60K (lazy-loaded)
- [x] Search "GNN" hits papers across multiple months (visual verified)
- [ ] CI green
- [ ] (manual) \`pnpm preview\` — focus input, see results stream in; toggle dark mode while results are visible

## Notes
- Index size will grow as backfill data lands. 812K with current content; should stay well under 5MB even after a few years of accumulation.
- Build time impact: +1.5s for indexing 103 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)