### PR TITLE
feat(astro): RSS feed + dynamic OG images per page

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,10 +12,13 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^6.1.9",
+    "astro-og-canvas": "^0.11.1",
     "astro-pagefind": "^1.8.6",
+    "canvaskit-wasm": "^0.41.1",
     "pagefind": "^1.5.2",
     "tailwindcss": "^4.2.4"
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -17,9 +20,15 @@ importers:
       astro:
         specifier: ^6.1.9
         version: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)
+      astro-og-canvas:
+        specifier: ^0.11.1
+        version: 0.11.1(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3))
       astro-pagefind:
         specifier: ^1.8.6
         version: 1.8.6(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3))
+      canvaskit-wasm:
+        specifier: ^0.41.1
+        version: 0.41.1
       pagefind:
         specifier: ^1.5.2
         version: 1.5.2
@@ -41,6 +50,9 @@ packages:
   '@astrojs/prism@4.0.1':
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
     engines: {node: '>=22.12.0'}
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
 
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
@@ -404,6 +416,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -750,6 +765,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@webgpu/types@0.1.21':
+    resolution: {integrity: sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -766,6 +784,11 @@ packages:
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
+  astro-og-canvas@0.11.1:
+    resolution: {integrity: sha512-6omy7MJeOPwxdYH5+eL3zFIY9MhuDRUMuASuCx/eXNrHGUogq9ZHdx19A428KtWhLVuXVcLt7Klw5fxqASAHmg==}
+    peerDependencies:
+      astro: ^5.0.0 || ^6.0.0-alpha
 
   astro-pagefind@1.8.6:
     resolution: {integrity: sha512-pofDcWMgA3qLQX9gSJ1mc3NSJDv6o1PDs68MrtdupxMFIlAFT2yckFSiOoaab2stSDmKyX/wVaTObyj5FuBulA==}
@@ -784,8 +807,14 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  base-64@1.0.0:
+    resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  canvaskit-wasm@0.41.1:
+    resolution: {integrity: sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -877,6 +906,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  deterministic-object-hash@2.0.2:
+    resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
+    engines: {node: '>=18'}
+
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
@@ -919,6 +952,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -948,6 +985,13 @@ packages:
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1347,6 +1391,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -1478,6 +1526,9 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -1760,6 +1811,12 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.7.2
+      piccolore: 0.1.3
+      zod: 4.3.6
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
@@ -2002,6 +2059,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodable/entities@2.1.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -2253,6 +2312,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@webgpu/types@0.1.21': {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -2265,6 +2326,13 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  astro-og-canvas@0.11.1(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)):
+    dependencies:
+      astro: 6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)
+      canvaskit-wasm: 0.41.1
+      deterministic-object-hash: 2.0.2
+      entities: 8.0.0
 
   astro-pagefind@1.8.6(astro@6.1.9(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.3)):
     dependencies:
@@ -2370,7 +2438,13 @@ snapshots:
 
   bail@2.0.2: {}
 
+  base-64@1.0.0: {}
+
   boolbase@1.0.0: {}
+
+  canvaskit-wasm@0.41.1:
+    dependencies:
+      '@webgpu/types': 0.1.21
 
   ccount@2.0.1: {}
 
@@ -2442,6 +2516,10 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  deterministic-object-hash@2.0.2:
+    dependencies:
+      base-64: 1.0.0
+
   devalue@5.7.1: {}
 
   devlop@1.1.0:
@@ -2480,6 +2558,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -2529,6 +2609,17 @@ snapshots:
   fast-wrap-ansi@0.1.6:
     dependencies:
       fast-string-width: 1.1.0
+
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3134,6 +3225,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-expression-matcher@1.5.0: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -3362,6 +3455,8 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strnum@2.2.3: {}
 
   svgo@4.0.1:
     dependencies:

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -6,14 +6,24 @@ import Footer from "../components/Footer.astro";
 interface Props {
   title: string;
   description?: string;
-  current?: "home" | "archive";
+  current?: "home" | "archive" | "search";
+  /** Slug under /og/ that maps to the page (e.g. "index", "archive",
+   * "archive/2026-03"). Layout builds the absolute og:image URL. */
+  ogSlug?: string;
 }
 
 const {
   title,
   description = "Daily-updated NLP arxiv paper digest",
   current = "home",
+  ogSlug = "index",
 } = Astro.props;
+
+const ogImage = new URL(
+  `${import.meta.env.BASE_URL.replace(/\/$/, "")}/og/${ogSlug}.png`,
+  Astro.site,
+).toString();
+const canonical = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <!doctype html>
@@ -22,7 +32,23 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
     <title>{title}</title>
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:url" content={canonical} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="NLP Arxiv Daily"
+      href={new URL(`${import.meta.env.BASE_URL.replace(/\/$/, "")}/rss.xml`, Astro.site).toString()}
+    />
     <!-- Pre-paint theme bootstrap. Reads stored preference, falls back to
          system pref, sets the .dark class before first paint to avoid FOUC.
          is:inline so Astro doesn't bundle it as a deferred module. -->

--- a/web/src/pages/archive/[month].astro
+++ b/web/src/pages/archive/[month].astro
@@ -28,6 +28,7 @@ const totalPapers = keywords.reduce(
   title={`${entry.id} — NLP Arxiv Daily`}
   description={`NLP arxiv papers from ${entry.id}`}
   current="archive"
+  ogSlug={`archive/${entry.id}`}
 >
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">

--- a/web/src/pages/archive/index.astro
+++ b/web/src/pages/archive/index.astro
@@ -16,7 +16,7 @@ for (const month of months) {
 }
 ---
 
-<Layout title="Archive — NLP Arxiv Daily" current="archive">
+<Layout title="Archive — NLP Arxiv Daily" current="archive" ogSlug="archive">
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Archive</h1>

--- a/web/src/pages/og/[...slug].png.ts
+++ b/web/src/pages/og/[...slug].png.ts
@@ -1,0 +1,71 @@
+import { OGImageRoute } from "astro-og-canvas";
+import { getCollection } from "astro:content";
+import currentPapers from "../../../../docs/nlp-arxiv-daily-web.json";
+import { paperBucketSchema } from "../../content.config.ts";
+
+interface OgPage {
+  title: string;
+  description: string;
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+const pages: Record<string, OgPage> = {
+  index: {
+    title: "NLP Arxiv Daily",
+    description: `Updated ${today}`,
+  },
+  archive: {
+    title: "Archive",
+    description: "Monthly snapshots — NLP Arxiv Daily",
+  },
+};
+
+// Add per-month archive cards.
+const archiveEntries = await getCollection("archive");
+for (const entry of archiveEntries) {
+  const data = paperBucketSchema.parse(entry.data);
+  const total = Object.values(data).reduce(
+    (sum, papers) => sum + Object.keys(papers).length,
+    0,
+  );
+  pages[`archive/${entry.id}`] = {
+    title: entry.id,
+    description: `${total} papers — NLP Arxiv Daily`,
+  };
+}
+
+// Current month also gets a "live" count.
+{
+  const data = paperBucketSchema.parse(currentPapers);
+  const total = Object.values(data).reduce(
+    (sum, papers) => sum + Object.keys(papers).length,
+    0,
+  );
+  pages.index.description = `${total} papers · Updated ${today}`;
+}
+
+export const prerender = true;
+
+// OGImageRoute returns a Promise — must await at module top.
+export const { getStaticPaths, GET } = await OGImageRoute({
+  param: "slug",
+  pages,
+  // Default getSlug appends ".png"; route file `[...slug].png.ts` already
+  // owns that extension, so return the path verbatim or we'd get `.png.png`.
+  getSlug: (path) => path,
+  getImageOptions: (_path, page: OgPage) => ({
+    title: page.title,
+    description: page.description,
+    bgGradient: [
+      [22, 23, 33],
+      [40, 42, 60],
+    ],
+    border: { color: [120, 120, 220], width: 6, side: "block-start" },
+    padding: 80,
+    font: {
+      title: { size: 80, weight: "Bold", color: [255, 255, 255], lineHeight: 1.2 },
+      description: { size: 36, color: [180, 180, 200], lineHeight: 1.4 },
+    },
+  }),
+});

--- a/web/src/pages/rss.xml.ts
+++ b/web/src/pages/rss.xml.ts
@@ -1,0 +1,45 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
+import { paperBucketSchema } from "../content.config.ts";
+import { parsePaperRow } from "../utils/paperRow.ts";
+
+interface FeedItem {
+  title: string;
+  link: string;
+  pubDate: Date;
+  description: string;
+  customData: string;
+}
+
+export async function GET(context: APIContext) {
+  const data = paperBucketSchema.parse(currentPapers);
+
+  const items: FeedItem[] = [];
+  for (const [keyword, papers] of Object.entries(data)) {
+    for (const [paperId, row] of Object.entries(papers)) {
+      const parsed = parsePaperRow(row);
+      if (!parsed) continue;
+      items.push({
+        title: parsed.title,
+        link: parsed.paperUrl,
+        pubDate: new Date(parsed.date),
+        description: `${parsed.firstAuthor} et al. — arxiv:${paperId} — ${keyword}`,
+        customData: `<category>${keyword}</category>`,
+      });
+    }
+  }
+  // Newest first.
+  items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+
+  // The channel <link> should point at the actual home page, which lives
+  // under the base path (/nlp-arxiv-daily/) — Astro.site by itself drops it.
+  const homeUrl = new URL(import.meta.env.BASE_URL, context.site!).toString();
+
+  return rss({
+    title: "NLP Arxiv Daily",
+    description: "Daily-refreshed NLP arxiv paper digest",
+    site: homeUrl,
+    items,
+  });
+}


### PR DESCRIPTION
## Summary
Two distribution wins:

- **\`/rss.xml\`** — one \`<item>\` per current-month paper, ordered date-desc. Title = paper title, description = author + arxiv id + keyword, link = paper_url, category = keyword. Channel \`<link>\` correctly anchored at \`https://monologg.kr/nlp-arxiv-daily/\` (Astro.site alone would drop the base path).
- **\`/og/<slug>.png\`** — 1200×630 PNGs rendered by \`astro-og-canvas\`. One per page: \`/og/index.png\`, \`/og/archive.png\`, \`/og/archive/YYYY-MM.png\`. Title shows date / month; description shows live paper count.

\`Layout.astro\` now emits the social meta surface:
- \`og:type / og:title / og:description / og:image / og:url\`
- \`twitter:card\` (summary_large_image)
- \`<link rel="canonical">\`
- \`<link rel="alternate" type="application/rss+xml">\`

Each page passes an \`ogSlug\` prop that Layout uses to build the absolute og:image URL.

## Wrinkles ironed out
- \`OGImageRoute\` returns a Promise — needs top-level await on the destructure.
- Endpoint default is server-rendered → must \`export const prerender = true\`.
- Default \`getSlug\` appends \`".png"\`, which combined with the route file \`[...slug].png.ts\` produced \`.png.png\`. Override \`getSlug\` to return the path verbatim.
- \`canvaskit-wasm\` is a peer dep pnpm doesn't auto-resolve; installed explicitly.

## Test plan
- [x] \`pnpm build\` → 103 HTML pages + **102 OG PNGs** + rss.xml + sitemap, **3.5s**
- [x] \`/og/index.png\`: 1200×630 PNG, RGBA
- [x] \`/rss.xml\` channel link → \`https://monologg.kr/nlp-arxiv-daily/\`
- [x] Items have author + arxiv id + keyword in description
- [ ] CI green
- [ ] (manual) \`pnpm preview\` — paste a /og/<slug>.png URL into Twitter / Slack debugger to confirm unfurl

🤖 Generated with [Claude Code](https://claude.com/claude-code)