### PR TITLE
fix: dark-mode specificity + display submission date instead of revision

### DIFF
--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -60,10 +60,20 @@ def _strip_version_suffix(short_id: str) -> str:
 
 
 def _result_to_paper(result) -> Paper:
+    """Convert an arxiv.Result to our Paper dataclass.
+
+    Uses `result.published.date()` (submission date), NOT
+    `result.updated.date()` (latest revision). Backfilled papers can have
+    revisions long after submission — the revision date scrambles them
+    across the wrong months in the archive UI (e.g. an Aug-2025 submission
+    revised in Jan 2026 was showing up dated 2026-01 inside /archive/2025-08/).
+    The arxiv id (`2508.xxxxx`) already encodes the submission month and
+    that's what we bucket by; the display date should match.
+    """
     short_id = result.get_short_id()
     paper_id = _strip_version_suffix(short_id)
     first_author = get_authors(result.authors, first_author=True)
-    update_time = result.updated.date()
+    update_time = result.published.date()
 
     logging.info(f"Time = {update_time} title = {result.title} author = {first_author}")
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -22,11 +22,15 @@ from nlp_arxiv_daily import cli, fetcher
 
 
 class _FakeArxivResult:
-    def __init__(self, *, short_id, title, updated, entry_id, summary="no code"):
+    def __init__(self, *, short_id, title, updated, entry_id, summary="no code", published=None):
         self._short_id = short_id
         self.title = title
         self.authors = ["Alice"]
         self.updated = updated
+        # Most tests don't care about the distinction; default published to
+        # `updated`. Tests that want to exercise the published vs updated
+        # mismatch (e.g. /archive/2025-08 bucket bug) pass it explicitly.
+        self.published = published or updated
         self.entry_id = entry_id
         self.summary = summary
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -20,6 +20,7 @@ class _FakeArxivResult:
         title: str = "A Title",
         authors: list[str] | None = None,
         updated: datetime.datetime | None = None,
+        published: datetime.datetime | None = None,
         entry_id: str = "http://arxiv.org/abs/X",
         summary: str = "no code link here",
     ):
@@ -27,6 +28,9 @@ class _FakeArxivResult:
         self.title = title
         self.authors = authors or ["Alice", "Bob"]
         self.updated = updated or datetime.datetime(2026, 4, 22, 0, 0, 0)
+        # Default published == updated unless overridden — keeps existing
+        # tests stable; the bucket-month bug case sets them differently.
+        self.published = published or self.updated
         self.entry_id = entry_id
         self.summary = summary
 
@@ -125,6 +129,29 @@ class TestFetchPapers:
         assert p.update_time == datetime.date(2026, 4, 22)
         assert p.paper_url == "http://arxiv.org/abs/2604.21637v1"
         assert p.code_link is None
+
+    def test_uses_published_not_updated_for_display_date(self, monkeypatch):
+        """Backfill regression: a Aug-2025 submission with a Jan-2026 revision
+        should show the submission date, not the revision date. Prior bug:
+        Paper.update_time = result.updated.date() bucketed Aug 2025 papers
+        in /archive/2025-08/ but rendered them with date 2026-01-XX.
+        """
+        _silence_code_link(monkeypatch)
+        _patch_arxiv(
+            monkeypatch,
+            [
+                _FakeArxivResult(
+                    short_id="2508.00001v2",
+                    published=datetime.datetime(2025, 8, 12, 9, 0, 0),
+                    updated=datetime.datetime(2026, 1, 27, 14, 0, 0),
+                )
+            ],
+        )
+
+        papers = fetch_papers(query="NLP", max_results=1)
+
+        assert papers[0].update_time == datetime.date(2025, 8, 12)
+        assert papers[0].update_time != datetime.date(2026, 1, 27)
 
     def test_handles_empty_result_set(self, monkeypatch):
         _silence_code_link(monkeypatch)

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -19,8 +19,11 @@
 }
 
 /* Dark-mode overrides. Token *names* stay identical so component code
-   doesn't branch — only the values change. */
-:where(.dark) {
+   doesn't branch — only the values change.
+   Use `html.dark` (not `:where(.dark)`) so the override has specificity
+   (0,1,1) > the (0,1,0) from `@theme`'s :root rule. With `:where()` the
+   selector specificity collapses to 0 and the override silently loses. */
+html.dark {
   --color-bg: oklch(0.16 0.015 260);
   --color-surface: oklch(0.21 0.015 260);
   --color-fg: oklch(0.95 0.005 260);

--- a/web/src/utils/paperRow.ts
+++ b/web/src/utils/paperRow.ts
@@ -1,18 +1,22 @@
 /**
  * Parse a legacy markdown paper row into structured fields.
  *
- * The Python pipeline (PRSL-66 renderer + cli) emits rows shaped like:
+ * The Python pipeline historically emitted TWO row formats and the
+ * gitpage-flavor archive JSONs ended up with both mixed in: bullet rows
+ * for recent backfilled months, pipe-table rows for everything older.
  *
- *   "- 2026-04-22, **Title**, Author et.al., Paper: [url](url)\n"
+ * Bullet (gitpage):
+ *   "- 2026-04-22, **Title**, Author et.al., Paper: [url](url)"
+ *   "- 2026-04-22, **Title**, Author et.al., Paper: [url](url), Code: **[ghurl](ghurl)**"
  *
- * or with a code link appended:
+ * Pipe (README, leaked into pre-2025-08 archive-web JSONs during the
+ * original backfill migration):
+ *   "|**2025-06-03**|**Title**|Author et.al.|[2506.02818v1](url)|null|"
+ *   "|**2025-06-03**|**Title**|Author et.al.|[id](url)|**[link](ghurl)**|"
  *
- *   "- 2026-04-22, **Title**, Author et.al., Paper: [url](url), Code: **[ghurl](ghurl)**\n"
- *
- * This parser is the read-side counterpart to `core.papers_to_legacy_rows`
- * on the Python side. The legacy markdown format is the JSON contract for
- * now; later tickets may flip to structured Paper JSON, at which point this
- * util goes away.
+ * We try the bullet regex first (preferred shape) and fall back to pipe.
+ * Either way the parser is the read-side counterpart to
+ * `core.papers_to_legacy_rows`.
  */
 export interface ParsedPaper {
   date: string; // ISO YYYY-MM-DD
@@ -22,21 +26,36 @@ export interface ParsedPaper {
   codeLink: string | null;
 }
 
-const ROW_RE =
-  // Anchor on the leading "- ", capture date, title, author, paper url, and optional code link.
+const BULLET_RE =
   /^-\s+(\d{4}-\d{2}-\d{2}),\s+\*\*(.+?)\*\*,\s+(.+?)\s+et\.al\.,\s+Paper:\s+\[(.+?)\]\(.+?\)(?:,\s+Code:\s+\*\*\[(.+?)\]\(.+?\)\*\*)?\s*$/;
 
+const PIPE_RE =
+  /^\|\*\*(\d{4}-\d{2}-\d{2})\*\*\|\*\*(.+?)\*\*\|(.+?)\s+et\.al\.\|\[.+?\]\((.+?)\)\|(.+?)\|\s*$/;
+
 export function parsePaperRow(row: string): ParsedPaper | null {
-  const match = row.trim().match(ROW_RE);
-  if (!match) return null;
-  const [, date, title, firstAuthor, paperUrl, codeLink] = match;
-  return {
-    date,
-    title,
-    firstAuthor,
-    paperUrl,
-    codeLink: codeLink ?? null,
-  };
+  const trimmed = row.trim();
+
+  const bullet = trimmed.match(BULLET_RE);
+  if (bullet) {
+    const [, date, title, firstAuthor, paperUrl, codeLink] = bullet;
+    return { date, title, firstAuthor, paperUrl, codeLink: codeLink ?? null };
+  }
+
+  const pipe = trimmed.match(PIPE_RE);
+  if (pipe) {
+    const [, date, title, firstAuthor, paperUrl, codeCell] = pipe;
+    // Pipe code cell is either "null" or "**[link](codeUrl)**".
+    const codeMatch = codeCell.match(/\*\*\[.+?\]\((.+?)\)\*\*/);
+    return {
+      date,
+      title,
+      firstAuthor,
+      paperUrl,
+      codeLink: codeMatch ? codeMatch[1] : null,
+    };
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Three production bugs surfaced after cutover

### 1. Theme toggle had no visual effect
\`:where(.dark) { --color-bg: ... }\` has specificity \`(0,0,0)\`. Tailwind v4's \`@theme\` block compiles to \`:root { --color-bg: ... }\` with \`(0,1,0)\` — **always wins regardless of cascade order**. Toggle was adding \`.dark\` correctly but the var override was silently discarded.

**Fix**: \`:where(.dark)\` → \`html.dark\`. Specificity \`(0,1,1)\` beats \`:root\`. Verified compiled CSS now emits \`html.dark{--color-bg:oklch(16%...);...}\`.

### 2. /archive/2025-08/ rendered papers dated 2026-01-27
Bucket by \`paper_id\` (e.g. \`2508.00001\` → 2025-08) but displayed \`result.updated.date()\` (latest revision). Backfilled papers often had revisions months after submission.

**Fix**: use \`result.published.date()\` (submission date — never moves). Extracted Result→Paper into a shared \`_result_to_paper\` helper. Added regression test \`test_uses_published_not_updated_for_display_date\`.

### 3. /archive/2025-06/ (and every older month) rendered "unparseable row" everywhere
\`docs/archive-web/*.json\` files have **two row formats mixed in**: bullet rows for recent backfilled months (2025-08+) but **pipe-table rows for everything older** (the pipe shape leaked in during the original archive migration long before this session).

**Fix**: \`parsePaperRow\` tries the bullet regex first, falls back to pipe. Pipe code cell is \`null\` or \`**[link](codeUrl)**\`; extracts codeUrl from the latter. Verified: \`/archive/2025-06/index.html\` now has zero unparseable fallbacks (was many).

## Test plan
- [x] 122 tests pass, coverage 95.2%
- [x] \`make check-quality\` clean
- [x] Astro build verifies dark CSS emits \`html.dark\` selector
- [x] Astro build verifies 2025-06 page renders zero "unparseable row" fallbacks
- [ ] CI green
- [ ] After merge: existing 2025-08 ~ 2026-03 JSONs have stale dates baked in (bug 2). Re-running \`python -m nlp_arxiv_daily backfill --start 2025-08 --end 2026-03\` refreshes them with submission dates. Older months (≤ 2025-07) keep their existing rows but render correctly thanks to the bilingual parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)