### PR TITLE
fix(astro): use Tailwind v4 var-shorthand for color tokens (dark mode)

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -2,8 +2,8 @@
 const today = new Date().toISOString().slice(0, 10);
 ---
 
-<footer class="border-t border-[--color-muted]/20 mt-16">
-  <div class="max-w-3xl mx-auto px-6 py-6 flex items-center justify-between text-sm text-[--color-muted]">
+<footer class="border-t border-(--color-muted)/20 mt-16">
+  <div class="max-w-3xl mx-auto px-6 py-6 flex items-center justify-between text-sm text-(--color-muted)">
     <span>Daily-refreshed NLP arxiv digest.</span>
     <span>Built {today}</span>
   </div>

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -9,7 +9,7 @@ interface Props {
 const { current = "home" } = Astro.props;
 ---
 
-<header class="border-b border-[--color-border]">
+<header class="border-b border-(--color-border)">
   <div class="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
     <a class="font-semibold tracking-tight" href={withBase("/")}>
       NLP Arxiv Daily
@@ -17,8 +17,8 @@ const { current = "home" } = Astro.props;
     <nav class="flex items-center gap-5 text-sm">
       <a
         class:list={[
-          "hover:text-[--color-accent]",
-          current === "home" && "font-medium text-[--color-accent]",
+          "hover:text-(--color-accent)",
+          current === "home" && "font-medium text-(--color-accent)",
         ]}
         href={withBase("/")}
       >
@@ -26,8 +26,8 @@ const { current = "home" } = Astro.props;
       </a>
       <a
         class:list={[
-          "hover:text-[--color-accent]",
-          current === "archive" && "font-medium text-[--color-accent]",
+          "hover:text-(--color-accent)",
+          current === "archive" && "font-medium text-(--color-accent)",
         ]}
         href={withBase("/archive/")}
       >
@@ -35,8 +35,8 @@ const { current = "home" } = Astro.props;
       </a>
       <a
         class:list={[
-          "inline-flex items-center justify-center w-9 h-9 rounded border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors",
-          current === "search" && "border-[--color-accent] text-[--color-accent]",
+          "inline-flex items-center justify-center w-9 h-9 rounded border border-(--color-border) hover:border-(--color-accent) hover:text-(--color-accent) transition-colors",
+          current === "search" && "border-(--color-accent) text-(--color-accent)",
         ]}
         href={withBase("/search/")}
         aria-label="Search"

--- a/web/src/components/KeywordFilter.astro
+++ b/web/src/components/KeywordFilter.astro
@@ -14,7 +14,7 @@ const { keywords } = Astro.props;
   <button
     type="button"
     data-filter-all
-    class="filter-pill px-3 py-1 text-sm rounded border border-[--color-border] hover:border-[--color-accent] data-[active=true]:bg-[--color-accent] data-[active=true]:text-[--color-accent-fg] data-[active=true]:border-[--color-accent] transition-colors"
+    class="filter-pill px-3 py-1 text-sm rounded border border-(--color-border) hover:border-(--color-accent) data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-accent-fg) data-[active=true]:border-(--color-accent) transition-colors"
     data-active="true"
   >
     All
@@ -26,7 +26,7 @@ const { keywords } = Astro.props;
         type="button"
         data-filter-keyword={slug}
         data-keyword-label={keyword}
-        class="filter-pill px-3 py-1 text-sm rounded border border-[--color-border] hover:border-[--color-accent] data-[active=true]:bg-[--color-accent] data-[active=true]:text-[--color-accent-fg] data-[active=true]:border-[--color-accent] transition-colors"
+        class="filter-pill px-3 py-1 text-sm rounded border border-(--color-border) hover:border-(--color-accent) data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-accent-fg) data-[active=true]:border-(--color-accent) transition-colors"
         data-active="false"
       >
         {keyword}

--- a/web/src/components/KeywordSection.astro
+++ b/web/src/components/KeywordSection.astro
@@ -13,9 +13,9 @@ const ordered = sortPapersDesc(papers);
 ---
 
 <section id={slug} class="mb-12 scroll-mt-20">
-  <header class="flex items-baseline justify-between mb-3 pb-2 border-b border-[--color-muted]/30">
+  <header class="flex items-baseline justify-between mb-3 pb-2 border-b border-(--color-muted)/30">
     <h2 class="text-2xl font-semibold">{keyword}</h2>
-    <span class="text-[--color-muted] text-sm">{ordered.length} paper{ordered.length === 1 ? "" : "s"}</span>
+    <span class="text-(--color-muted) text-sm">{ordered.length} paper{ordered.length === 1 ? "" : "s"}</span>
   </header>
   {ordered.map(([paperId, row]) => (
     <PaperCard paperId={paperId} row={row} />

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -12,13 +12,13 @@ const parsed = parsePaperRow(row);
 
 {parsed ? (
   <article
-    class="py-3 border-b border-[--color-border] last:border-b-0"
+    class="py-3 border-b border-(--color-border) last:border-b-0"
     data-pagefind-body
   >
     <div class="flex items-baseline justify-between gap-3 mb-1">
       <h3 class="font-medium leading-snug" data-pagefind-meta="title">
         <a
-          class="hover:text-[--color-accent] hover:underline"
+          class="hover:text-(--color-accent) hover:underline"
           href={parsed.paperUrl}
           target="_blank"
           rel="noopener"
@@ -26,14 +26,14 @@ const parsed = parsePaperRow(row);
           {parsed.title}
         </a>
       </h3>
-      <time class="text-[--color-muted] text-xs whitespace-nowrap shrink-0" data-pagefind-meta="date">
+      <time class="text-(--color-muted) text-xs whitespace-nowrap shrink-0" data-pagefind-meta="date">
         {parsed.date}
       </time>
     </div>
-    <div class="flex items-center gap-3 text-sm text-[--color-muted]">
+    <div class="flex items-center gap-3 text-sm text-(--color-muted)">
       <span data-pagefind-meta="author">{parsed.firstAuthor} et al.</span>
       <a
-        class="text-[--color-accent] hover:underline"
+        class="text-(--color-accent) hover:underline"
         href={parsed.paperUrl}
         target="_blank"
         rel="noopener"
@@ -43,7 +43,7 @@ const parsed = parsePaperRow(row);
       </a>
       {parsed.codeLink && (
         <a
-          class="text-[--color-accent] hover:underline"
+          class="text-(--color-accent) hover:underline"
           href={parsed.codeLink}
           target="_blank"
           rel="noopener"
@@ -55,7 +55,7 @@ const parsed = parsePaperRow(row);
     </div>
   </article>
 ) : (
-  <article class="py-3 border-b border-[--color-muted]/15 last:border-b-0 text-[--color-muted] text-sm">
+  <article class="py-3 border-b border-(--color-muted)/15 last:border-b-0 text-(--color-muted) text-sm">
     <span>{paperId}</span> — unparseable row
   </article>
 )}

--- a/web/src/components/TableOfContents.astro
+++ b/web/src/components/TableOfContents.astro
@@ -6,8 +6,8 @@ interface Props {
 const { keywords } = Astro.props;
 ---
 
-<nav class="mb-10 p-4 rounded border border-[--color-muted]/20 bg-[--color-muted]/5">
-  <h2 class="text-sm font-semibold uppercase tracking-wide text-[--color-muted] mb-2">
+<nav class="mb-10 p-4 rounded border border-(--color-muted)/20 bg-(--color-muted)/5">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-(--color-muted) mb-2">
     Table of Contents
   </h2>
   <ul class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
@@ -15,10 +15,10 @@ const { keywords } = Astro.props;
       const slug = keyword.toLowerCase().replace(/\s+/g, "-");
       return (
         <li>
-          <a class="text-[--color-accent] hover:underline" href={`#${slug}`}>
+          <a class="text-(--color-accent) hover:underline" href={`#${slug}`}>
             {keyword}
           </a>
-          <span class="text-[--color-muted]"> ({Object.keys(papers).length})</span>
+          <span class="text-(--color-muted)"> ({Object.keys(papers).length})</span>
         </li>
       );
     })}

--- a/web/src/components/ThemeToggle.astro
+++ b/web/src/components/ThemeToggle.astro
@@ -8,7 +8,7 @@
   id="theme-toggle"
   type="button"
   aria-label="Toggle theme"
-  class="inline-flex items-center justify-center w-9 h-9 rounded border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
+  class="inline-flex items-center justify-center w-9 h-9 rounded border border-(--color-border) hover:border-(--color-accent) hover:text-(--color-accent) transition-colors"
 >
   {/* Sun icon — visible in dark mode (because .dark hides the moon below). */}
   <svg

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -68,7 +68,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
       })();
     </script>
   </head>
-  <body class="bg-[--color-bg] text-[--color-fg] font-sans min-h-screen flex flex-col antialiased">
+  <body class="bg-(--color-bg) text-(--color-fg) font-sans min-h-screen flex flex-col antialiased">
     <Header current={current} />
     <div class="flex-1">
       <slot />

--- a/web/src/pages/archive/[month].astro
+++ b/web/src/pages/archive/[month].astro
@@ -32,13 +32,13 @@ const totalPapers = keywords.reduce(
 >
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
-      <p class="text-sm text-[--color-muted] mb-2">
-        <a class="hover:text-[--color-accent] hover:underline" href={withBase("/archive/")}>
+      <p class="text-sm text-(--color-muted) mb-2">
+        <a class="hover:text-(--color-accent) hover:underline" href={withBase("/archive/")}>
           ← all archives
         </a>
       </p>
       <h1 class="text-4xl font-bold mb-2">{entry.id}</h1>
-      <p class="text-[--color-muted] text-sm">
+      <p class="text-(--color-muted) text-sm">
         {totalPapers} papers across {keywords.length} keywords.
       </p>
     </header>
@@ -51,7 +51,7 @@ const totalPapers = keywords.reduce(
         ))}
       </>
     ) : (
-      <p class="text-[--color-muted]">No papers in this snapshot.</p>
+      <p class="text-(--color-muted)">No papers in this snapshot.</p>
     )}
   </main>
 </Layout>

--- a/web/src/pages/archive/index.astro
+++ b/web/src/pages/archive/index.astro
@@ -20,7 +20,7 @@ for (const month of months) {
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Archive</h1>
-      <p class="text-[--color-muted] text-sm">
+      <p class="text-(--color-muted) text-sm">
         {months.length} monthly snapshots since {months[months.length - 1]}.
       </p>
     </header>
@@ -32,7 +32,7 @@ for (const month of months) {
           {items.map((month) => (
             <li>
               <a
-                class="inline-block px-3 py-1 rounded border border-[--color-muted]/30 hover:border-[--color-accent] hover:text-[--color-accent] text-sm"
+                class="inline-block px-3 py-1 rounded border border-(--color-muted)/30 hover:border-(--color-accent) hover:text-(--color-accent) text-sm"
                 href={withBase(`/archive/${month}/`)}
               >
                 {month}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -21,7 +21,7 @@ const today = new Date().toISOString().slice(0, 10);
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Updated {today}</h1>
-      <p class="text-[--color-muted] text-sm">
+      <p class="text-(--color-muted) text-sm">
         {totalPapers} papers across {keywords.length} keywords this month.
       </p>
     </header>
@@ -35,7 +35,7 @@ const today = new Date().toISOString().slice(0, 10);
         ))}
       </>
     ) : (
-      <p class="text-[--color-muted]">
+      <p class="text-(--color-muted)">
         No papers published yet this month — the cron picks them up daily.
       </p>
     )}

--- a/web/src/pages/search.astro
+++ b/web/src/pages/search.astro
@@ -7,7 +7,7 @@ import Search from "astro-pagefind/components/Search";
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-6">
       <h1 class="text-4xl font-bold mb-2">Search</h1>
-      <p class="text-[--color-muted] text-sm">
+      <p class="text-(--color-muted) text-sm">
         Full-text across every paper in the archive.
       </p>
     </header>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -5,8 +5,10 @@
    stored preference, before first paint. */
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Light-mode palette. The token names are referenced by Tailwind's arbitrary
-   value syntax (e.g. `bg-[--color-bg]`) and via plain CSS vars. */
+/* Light-mode palette. Referenced via Tailwind v4's CSS-variable shorthand
+   (`bg-(--color-bg)`) — note parens, not brackets. The bracket form
+   `bg-[--color-bg]` is a Tailwind v4 footgun: it emits the literal token
+   `--color-bg` as the property value (invalid CSS) instead of `var(...)`. */
 @theme {
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --color-bg: oklch(0.99 0 0);


### PR DESCRIPTION
## Summary
- `bg-[--color-bg]` is a Tailwind v4 footgun — bracket form emits the literal `background-color: --color-bg` (invalid CSS), not `var(--color-bg)`. Body bg never resolved to a real color, so toggling `.dark` updated the CSS variables but nothing read them. Result: dark-mode toggle had no visible effect.
- Replaced every `[--color-X]` (and `[--color-X]/N` opacity variants) with `(--color-X)` across components, layouts, and pages.
- Updated `global.css` comment to call out the bracket-vs-paren gotcha.

Compiled CSS now emits `background-color: var(--color-bg)` etc., and dark mode actually flips colors.

## Test plan
- [x] `pnpm build` succeeds
- [x] `grep "background-color:" dist/_astro/*.css` shows `var(--color-bg)` (not the literal `--color-bg`)
- [ ] After deploy: click sun/moon button on the live site → page background + text recolor
- [ ] System dark pref + first load → page paints in dark theme without FOUC

🤖 Generated with [Claude Code](https://claude.com/claude-code)