### PR TITLE
feat(astro): add GitHub repo link to header

### DIFF
--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -56,6 +56,25 @@ const { current = "home" } = Astro.props;
           <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>
       </a>
+      <a
+        class="inline-flex items-center justify-center w-9 h-9 rounded border border-(--color-border) hover:border-(--color-accent) hover:text-(--color-accent) transition-colors"
+        href="https://github.com/monologg/nlp-arxiv-daily"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="GitHub repository"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 .5C5.73.5.74 5.49.74 11.76c0 5.02 3.25 9.27 7.76 10.78.57.1.78-.25.78-.55 0-.27-.01-1.17-.02-2.12-3.16.69-3.83-1.34-3.83-1.34-.52-1.31-1.27-1.66-1.27-1.66-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.52-.29-5.18-1.26-5.18-5.62 0-1.24.45-2.26 1.18-3.05-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.17a10.93 10.93 0 0 1 5.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.59.23 2.76.11 3.05.74.79 1.18 1.81 1.18 3.05 0 4.37-2.67 5.33-5.2 5.61.41.36.78 1.05.78 2.12 0 1.53-.01 2.76-.01 3.14 0 .31.21.66.79.55 4.51-1.51 7.76-5.76 7.76-10.78C23.26 5.49 18.27.5 12 .5z"
+          ></path>
+        </svg>
+      </a>
       <ThemeToggle />
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- Add a GitHub icon link in the site header that opens https://github.com/monologg/nlp-arxiv-daily in a new tab
- Styled to match the existing search icon button (same square outlined button with hover accent)
- Includes `aria-label` and `rel="noopener noreferrer"` for accessibility/security

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] GitHub icon visible in header on desktop and mobile
- [ ] Clicking the icon opens the repo in a new tab
- [ ] Hover state matches the search button (border/text turns accent color)
- [ ] Dark mode rendering looks correct