### PR TITLE
fix: trigger Astro Build & Deploy after daily cron commit

### DIFF
--- a/.github/workflows/astro-build.yml
+++ b/.github/workflows/astro-build.yml
@@ -4,11 +4,12 @@ name: Astro Build & Deploy
 #
 # Triggers:
 # - web/**            — frontend code or theme changes
-# - docs/**.json      — cron-committed paper data the Astro build consumes
-#                       (cron runs `python -m nlp_arxiv_daily run`, which
-#                       writes the gitpage JSONs; this workflow then
-#                       rebuilds + redeploys)
+# - docs/**.json      — paper data the Astro build consumes (human pushes only)
 # - the workflow yaml — self-changes
+# - workflow_run      — fires after the daily cron commits new JSONs.
+#                       Needed because the cron pushes via GITHUB_TOKEN,
+#                       which by design does NOT trigger downstream `push`
+#                       events; without this hook the site never rebuilds.
 #
 # Repo Settings → Pages → Source must be set to "GitHub Actions" for the
 # deploy job to publish.
@@ -25,6 +26,10 @@ on:
     paths:
       - "web/**"
       - ".github/workflows/astro-build.yml"
+  workflow_run:
+    workflows: ["Run Arxiv Papers Daily"]
+    types: [completed]
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -43,6 +48,8 @@ concurrency:
 jobs:
   build:
     name: build
+    # Skip when the upstream cron failed — no point rebuilding stale data.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -79,7 +86,7 @@ jobs:
   deploy:
     name: deploy
     needs: build
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- 데일리 cron이 매일 `docs/nlp-arxiv-daily-web.json` 등을 갱신하지만 Astro 사이트가 재빌드되지 않던 문제를 수정. 원인은 `secrets.GITHUB_TOKEN`으로 push한 commit은 후속 워크플로우의 `push` 이벤트를 트리거하지 않는 GitHub의 의도된 동작 — 실제로 최근 10개 Astro Build 트리거가 전부 PR merge였고 봇 commit은 0회.
- `astro-build.yml`에 `workflow_run` 트리거 추가 (`Run Arxiv Papers Daily` 완료 시 master 한정). build job은 upstream cron이 success일 때만 돌도록 가드, deploy job도 `workflow_run` 이벤트에 대해 배포하도록 조건 확장.

## Test plan
- [x] yaml syntax 확인
- [ ] 머지 후 다음 데일리 cron(또는 수동 dispatch) 종료 시 Astro Build & Deploy가 자동으로 트리거되는지 확인
- [ ] 사이트(GitHub Pages)에 새 데이터가 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)