### PR TITLE
fix: add whitespace around OR in pretty_filters

### DIFF
--- a/nlp_arxiv_daily/core.py
+++ b/nlp_arxiv_daily/core.py
@@ -44,7 +44,9 @@ def load_config(config_file: str) -> dict:
         keywords = {}
         EXCAPE = '"'
         QUOTA = ""  # NO-USE
-        OR = "OR"  # TODO
+        # Whitespace around OR is required — arxiv parses `NLPOR"..."` as a
+        # single token, which yields no results and triggers 429s on retry.
+        OR = " OR "
 
         def parse_filters(filters: list):
             ret = ""

--- a/tests/test_daily_arxiv.py
+++ b/tests/test_daily_arxiv.py
@@ -97,7 +97,9 @@ class TestLoadConfig:
 
     def test_quotes_multi_word_filters(self, config_file):
         config = load_config(config_file)
-        assert config["kv"]["NLP"] == 'NLPOR"Natural Language Processing"'
+        # arxiv requires whitespace around `OR`; without it the query becomes
+        # one token (e.g. `NLPOR"..."`) and arxiv 429s on retry storms.
+        assert config["kv"]["NLP"] == 'NLP OR "Natural Language Processing"'
 
     def test_single_word_filter_left_unquoted(self, config_file):
         config = load_config(config_file)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -188,7 +188,7 @@ class TestFetchPapersInRange:
         captured = _patch_arxiv(monkeypatch, [])
 
         fetch_papers_in_range(
-            query='NLPOR"Natural Language Processing"',
+            query='NLP OR "Natural Language Processing"',
             start=datetime.date(2025, 8, 1),
             end=datetime.date(2025, 8, 31),
             max_results=500,
@@ -197,7 +197,7 @@ class TestFetchPapersInRange:
         assert captured["search"] is not None
         q = captured["search"].query
         # Combined: keyword filter wrapped in parens AND submittedDate range.
-        assert '(NLPOR"Natural Language Processing")' in q
+        assert '(NLP OR "Natural Language Processing")' in q
         assert "submittedDate:[202508010000 TO 202508312359]" in q
         assert " AND " in q
         assert captured["search"].max_results == 500


### PR DESCRIPTION
## Summary
- 데일리 cron이 계속 실패하던 진짜 원인은 `core.py`의 `OR = \"OR\"` 였음 — `pretty_filters`가 `[\"NLP\", \"Natural Language Processing\"]`을 합치면 `NLPOR\"Natural Language Processing\"`이라는 malformed query가 만들어져서 arxiv가 [같은 URL에 429를 뱉음](https://github.com/monologg/nlp-arxiv-daily/actions/runs/25108910154/job/73577291566).
- `OR = \" OR \"`로 한 줄 수정 → `NLP OR \"Natural Language Processing\"` 정상 query.
- PR #54의 retry/throttle 강화는 증상 완화였고, 이 PR이 root cause fix.
- 테스트 2개(`test_daily_arxiv.py`, `test_fetcher.py`)가 버그를 expected output으로 박아두고 있어서 같이 수정. (이래서 그동안 안 잡혔음)

## Test plan
- [x] `make test` — 137 passed
- [x] `make check-quality` — ruff clean
- [ ] 머지 후 다음 daily cron run에서 NLP/Legal NLP/Medical NLP/Multilingual NLP 등 multi-filter 키워드들이 실제 결과를 가져오는지 확인 (이전엔 0건이었을 가능성 높음)