### PR TITLE
fix: throttle daily arxiv fetch harder to survive 429s

### DIFF
--- a/.github/workflows/nlp-arxiv-daily.yml
+++ b/.github/workflows/nlp-arxiv-daily.yml
@@ -3,7 +3,9 @@ name: Run Arxiv Papers Daily
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0/12 * * *"
+    # Off-peak (avoid the top-of-hour herd of cron jobs that compete for
+    # GH-Actions egress IPs and tend to trip arxiv's per-IP 429 throttle).
+    - cron: "17 1,13 * * *"
 
 env:
   GITHUB_USER_NAME: nlp-arxiv-daily-bot

--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -26,13 +26,18 @@ GITHUB_URL_RE = re.compile(r"https?://github\.com/[\w.-]+/[\w.-]+")
 
 # arxiv API publishes a 3s minimum between requests, but multi-keyword
 # back-to-back fetches and bulk backfill pagination both trigger 429s in
-# practice — use a more conservative gap shared between daily and backfill.
-DAILY_RATE_LIMIT_SECONDS = 5
+# practice — and GH Actions IPs get throttled harder than typical clients,
+# so we go well above the published minimum.
+DAILY_RATE_LIMIT_SECONDS = 15
 BACKFILL_RATE_LIMIT_SECONDS = 5
 # arxiv.Client default is 3 in-library retries (fixed interval); bump it
 # before our outer tenacity retry kicks in.
 DAILY_NUM_RETRIES = 10
 BACKFILL_NUM_RETRIES = 10
+# config caps display at max_results=10 per keyword, so a library-default
+# page_size=100 just inflates response payloads without giving us anything.
+# Smaller pages also reduce the chance of tripping arxiv's per-IP throttle.
+DAILY_PAGE_SIZE = 20
 # Default upper bound per (keyword, month) backfill query — busy keywords
 # can return hundreds of arxiv submissions in a single month.
 BACKFILL_DEFAULT_MAX_RESULTS = 2000
@@ -53,6 +58,7 @@ def _get_daily_client() -> arxiv.Client:
     global _DAILY_CLIENT
     if _DAILY_CLIENT is None:
         _DAILY_CLIENT = arxiv.Client(
+            page_size=DAILY_PAGE_SIZE,
             delay_seconds=DAILY_RATE_LIMIT_SECONDS,
             num_retries=DAILY_NUM_RETRIES,
         )

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -358,11 +358,15 @@ class TestFetchPapersSharedClient:
         fetch_papers(query="x", max_results=1)
         kwargs = captured["client_kwargs"]
         assert kwargs is not None
-        # arxiv API publishes 3s minimum; we go higher to survive multi-keyword
-        # back-to-back fetches that share the daily client.
-        assert kwargs.get("delay_seconds", 0) >= 5
+        # arxiv API publishes 3s minimum; we go far higher because GH Actions
+        # IPs get throttled hard and 5s wasn't enough to keep daily cron green.
+        assert kwargs.get("delay_seconds", 0) >= 15
         # Library default is 3; bump so transient 429 storms don't kill the run.
         assert kwargs.get("num_retries", 0) >= 10
+        # page_size caps response payload size — config asks for max_results=10
+        # per keyword, so 100 (library default) wastes bandwidth and is more
+        # likely to trip arxiv's per-IP throttle.
+        assert kwargs.get("page_size", 100) <= 20
 
     def test_shares_client_across_calls(self, monkeypatch):
         _silence_code_link(monkeypatch)


### PR DESCRIPTION
## Summary
PR #58은 malformed query를 고쳤지만, daily cron은 여전히 GH Actions IP가 arxiv 측에서 throttle되는 환경 이슈로 429를 맞고 있음. 3개 knob로 요청 강도/타이밍을 줄임:

- **`DAILY_RATE_LIMIT_SECONDS` 5 → 15s** (25 키워드 × 15s ≈ 6분, daily cron 수용 충분)
- **`page_size` 100 → 20** (config가 `max_results=10`만 표시하니 100건 페이지는 응답만 부풀리고 throttle signal만 추가). arxiv lib에서 client 생성자 인자로 노출됨.
- **cron 00:00/12:00 UTC → 01:17/13:17 UTC** — 정각의 cron 군집을 피해 공유 egress IP 경합 줄임.

backfill 경로는 손대지 않음 (별개 client, hot path 아님).

## Test plan
- [x] `make test` — 137 passed (`test_uses_rate_limited_client_kwargs` 강화)
- [x] `make check-quality` — clean
- [ ] 머지 후 다음 cron run(13:17 UTC) 결과 확인 — 이번에도 429면 #2/#5 옵션(retry backoff 확장 / cron 1일 1회)으로 진행