### PR TITLE
fix: fall back to latest archive month when current month is empty

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,7 +45,7 @@ def test_get_daily_papers_end_to_end():
     for line in papers.values():
         assert line.startswith("|**"), f"unexpected row prefix: {line!r}"
         assert "et.al." in line
-        assert "|[link](" in line or "|null|" in line
+        assert "|**[link](" in line or "|null|" in line
 
     for line in web_papers.values():
         assert line.startswith("- ")

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -5,11 +5,39 @@ import KeywordSection from "../components/KeywordSection.astro";
 import TableOfContents from "../components/TableOfContents.astro";
 import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../content.config.ts";
+import { withBase } from "../utils/url.ts";
+import { getCollection } from "astro:content";
 
-const data = paperBucketSchema.parse(currentPapers);
-const keywords = Object.entries(data).filter(
+const currentData = paperBucketSchema.parse(currentPapers);
+const currentKeywords = Object.entries(currentData).filter(
   ([, papers]) => Object.keys(papers).length > 0,
 );
+
+let data = currentData;
+let keywords = currentKeywords;
+let fallbackMonth: string | null = null;
+
+if (currentKeywords.length === 0) {
+  const entries = await getCollection("archive");
+  const candidates = entries
+    .map((e) => ({
+      id: e.id,
+      data: e.data,
+      keywords: Object.entries(e.data).filter(
+        ([, papers]) => Object.keys(papers).length > 0,
+      ),
+    }))
+    .filter((c) => c.keywords.length > 0)
+    .sort((a, b) => b.id.localeCompare(a.id));
+
+  if (candidates.length > 0) {
+    const latest = candidates[0];
+    data = latest.data;
+    keywords = latest.keywords;
+    fallbackMonth = latest.id;
+  }
+}
+
 const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
   0,
@@ -21,9 +49,20 @@ const today = new Date().toISOString().slice(0, 10);
   <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Updated {today}</h1>
-      <p class="text-(--color-muted) text-sm">
-        {totalPapers} papers across {keywords.length} keywords this month.
-      </p>
+      {fallbackMonth ? (
+        <p class="text-(--color-muted) text-sm">
+          No papers yet this month — showing the latest snapshot from
+          {" "}
+          <a class="hover:text-(--color-accent) hover:underline" href={withBase(`/archive/${fallbackMonth}/`)}>
+            {fallbackMonth}
+          </a>
+          {" "}({totalPapers} papers across {keywords.length} keywords).
+        </p>
+      ) : (
+        <p class="text-(--color-muted) text-sm">
+          {totalPapers} papers across {keywords.length} keywords this month.
+        </p>
+      )}
     </header>
 
     {keywords.length > 0 ? (


### PR DESCRIPTION
## Summary
- 새로운 달이 시작되어 `docs/nlp-arxiv-daily-web.json`이 비어 있을 때 홈 페이지가 텅 비어 보이는 문제 수정
- 빌드 타임에 `archive` 컬렉션에서 데이터가 있는 가장 최신 월을 찾아 폴백으로 렌더
- 헤더에 "No papers yet this month — showing the latest snapshot from YYYY-MM" 안내 문구와 해당 archive 페이지 링크 표시
- 현재 달에 데이터가 들어오기 시작하면 기존 분기로 자동 복귀

## Test plan
- [x] `pnpm build` 성공 (104 pages)
- [x] 빌드 결과 `dist/index.html`에 폴백 안내 문구 + `/archive/2026-04/` 링크 + 5444 papers 렌더 확인
- [ ] 5월 데이터가 들어왔을 때 폴백 분기를 건너뛰고 이번 달 데이터가 정상 표시되는지 확인 (시간 경과 후 자동 검증)