### PR TITLE
fix: tolerate per-keyword arxiv failures in daily fetch

### DIFF
--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -38,13 +38,33 @@ def cmd_fetch(config: dict) -> None:
     data_collector_web = []
 
     logging.info("GET daily papers begin")
+    failed_keywords: list[str] = []
     for topic, keyword in keywords.items():
         logging.info(f"Keyword: {topic}")
-        data, data_web = get_daily_papers(topic, query=keyword, max_results=max_results)
+        try:
+            data, data_web = get_daily_papers(topic, query=keyword, max_results=max_results)
+        except Exception as e:
+            # One keyword exhausting arxiv's retries (429/503 storm) must not
+            # abort the whole daily run. write_papers_split merges onto existing
+            # main+archive JSON, so a skipped keyword simply keeps its prior data
+            # this run instead of nuking the published site. Mirrors cmd_backfill.
+            logging.warning(f"FETCH skip {topic}: {e}")
+            failed_keywords.append(topic)
+            continue
         data_collector.append(data)
         data_collector_web.append(data_web)
         logging.info("")
     logging.info("GET daily papers end")
+
+    if failed_keywords:
+        logging.warning(
+            f"FETCH completed with {len(failed_keywords)} skipped keyword(s): " + ", ".join(failed_keywords)
+        )
+        # Every keyword failing usually means a total arxiv outage / IP ban, not
+        # a per-keyword fluke — surface that as a hard failure so the cron run
+        # goes red instead of silently committing a no-op.
+        if len(failed_keywords) == len(keywords):
+            raise RuntimeError(f"all {len(keywords)} keyword fetches failed: {', '.join(failed_keywords)}")
 
     if config["publish_readme"]:
         write_papers_split(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,6 +132,65 @@ class TestCommandIsolation:
         cli.main(["--config_path", fake_config_file, "fetch"])
 
 
+class TestCmdFetchResilience:
+    """A single keyword's arxiv failure (e.g. a 429/503 storm) must not kill
+    the whole daily run — the surviving keywords still get persisted."""
+
+    def _config(self, tmp_path):
+        json_dir = tmp_path / "docs"
+        json_dir.mkdir(exist_ok=True)
+        archive_web_dir = json_dir / "archive-web"
+        archive_web_dir.mkdir(exist_ok=True)
+        (json_dir / "main-web.json").write_text("{}")
+        return {
+            "kv": {"NLP": "NLP", "LLM": "LLM"},
+            "max_results": 1,
+            "publish_readme": False,
+            "publish_gitpage": True,
+            "json_gitpage_path": str(json_dir / "main-web.json"),
+            "archive_gitpage_json_dir": str(archive_web_dir),
+        }
+
+    def test_one_keyword_failure_does_not_abort_run(self, monkeypatch, tmp_path):
+        import json
+
+        import arxiv
+
+        def fake_get_daily_papers(topic, query, max_results):
+            if topic == "NLP":
+                raise arxiv.HTTPError("https://export.arxiv.org/api/query", 1, 429)
+            # YYMM prefix must match the current month so it lands in main-web.json
+            # (not the archive). bucket_by_month buckets by the id's YYMM prefix.
+            import datetime
+
+            today = datetime.date.today()
+            key = f"{today.year % 100:02d}{today.month:02d}.00001"
+            row = {topic: {key: "ok\n"}}
+            return row, row
+
+        monkeypatch.setattr(cli, "get_daily_papers", fake_get_daily_papers)
+
+        config = self._config(tmp_path)
+        # Must not raise even though NLP keyword 429s.
+        cli.cmd_fetch(config)
+
+        # The surviving keyword (LLM) was still persisted.
+        written = json.loads((tmp_path / "docs" / "main-web.json").read_text())
+        assert "LLM" in written
+        assert "NLP" not in written
+
+    def test_all_keywords_failing_raises(self, monkeypatch, tmp_path):
+        import arxiv
+
+        def boom(topic, query, max_results):
+            raise arxiv.HTTPError("https://export.arxiv.org/api/query", 1, 503)
+
+        monkeypatch.setattr(cli, "get_daily_papers", boom)
+
+        with pytest.raises(RuntimeError, match="all .* keyword fetches failed"):
+            cli.cmd_fetch(self._config(tmp_path))
+
+
 class TestCmdRunInvocation:
     def test_run_calls_fetch_then_render_in_order(self, monkeypatch, fake_config_file):
         order = []


### PR DESCRIPTION
## Summary
- 최근 daily cron(`Run Arxiv Papers Daily`)이 연속 실패 중 — arXiv API의 rate limiting(`HTTP 429 Rate exceeded` / `503`) 때문. config 키워드 28개 중 **하나라도** 재시도 소진 시 전체 run이 죽어 사이트가 갱신되지 않았다.
- `cmd_fetch`에 backfill(#30)과 동일한 skip-on-failure 패턴 적용: 실패한 키워드는 로그 남기고 skip 후 계속 진행. `write_papers_split`이 기존 JSON에 merge하므로 skip된 키워드는 이전 데이터를 유지한다.
- **모든** 키워드가 실패할 때만(전면 장애/IP 차단) `RuntimeError`로 hard-fail → 조용한 no-op 커밋 대신 cron이 빨간불로 뜬다.

## Notes
- 이건 회복력 개선이며 rate limit 자체의 근본 해결은 아니다. 후속으로 키워드 OR 병합, 필드 prefix(`all:`/`cat:`), 호출 간격 상향을 검토할 수 있다.

## Test plan
- [x] `tests/test_cli.py::TestCmdFetchResilience` 추가 (부분 실패 / 전체 실패 2케이스), TDD로 실패 → 구현 → 통과 확인
- [x] 전체 스위트 139 passed, coverage 94.8%
- [x] `ruff check` / `ruff format --check` 통과