### PR TITLE
fix: prefix arxiv query terms with explicit all: field

### DIFF
--- a/nlp_arxiv_daily/core.py
+++ b/nlp_arxiv_daily/core.py
@@ -43,7 +43,12 @@ def load_config(config_file: str) -> dict:
     def pretty_filters(**config) -> dict:
         keywords = {}
         EXCAPE = '"'
-        QUOTA = ""  # NO-USE
+        # Explicit field prefix. arxiv defaults a bare term to an all-field
+        # search anyway, but only an explicit `all:` makes the query parser
+        # deterministic — a bare `NLP OR "..."` can be mis-grouped, which
+        # silently returns the wrong set (or nothing) and feeds the 429 retry
+        # storm. Prefixing every term sidesteps the parser's guesswork.
+        FIELD = "all:"
         # Whitespace around OR is required — arxiv parses `NLPOR"..."` as a
         # single token, which yields no results and triggers 429s on retry.
         OR = " OR "
@@ -53,9 +58,9 @@ def load_config(config_file: str) -> dict:
             for idx in range(0, len(filters)):
                 filter = filters[idx]
                 if len(filter.split()) > 1:
-                    ret += EXCAPE + filter + EXCAPE
+                    ret += FIELD + EXCAPE + filter + EXCAPE
                 else:
-                    ret += QUOTA + filter + QUOTA
+                    ret += FIELD + filter
                 if idx != len(filters) - 1:
                     ret += OR
             return ret

--- a/tests/test_daily_arxiv.py
+++ b/tests/test_daily_arxiv.py
@@ -97,13 +97,15 @@ class TestLoadConfig:
 
     def test_quotes_multi_word_filters(self, config_file):
         config = load_config(config_file)
-        # arxiv requires whitespace around `OR`; without it the query becomes
-        # one token (e.g. `NLPOR"..."`) and arxiv 429s on retry storms.
-        assert config["kv"]["NLP"] == 'NLP OR "Natural Language Processing"'
+        # Each term gets an explicit `all:` field prefix so arxiv's query parser
+        # treats it deterministically instead of guessing the field. arxiv
+        # requires whitespace around `OR`; without it the query becomes one
+        # token (e.g. `NLPOR"..."`) and arxiv 429s on retry storms.
+        assert config["kv"]["NLP"] == 'all:NLP OR all:"Natural Language Processing"'
 
-    def test_single_word_filter_left_unquoted(self, config_file):
+    def test_single_word_filter_gets_field_prefix(self, config_file):
         config = load_config(config_file)
-        assert config["kv"]["QA"] == "QA"
+        assert config["kv"]["QA"] == "all:QA"
 
 
 class _FakeResponse:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -133,7 +133,7 @@ class TestEndToEndPipeline:
                 entry_id="http://arxiv.org/abs/2508.12345v2",
             ),
         ]
-        _patch_arxiv(monkeypatch, {"NLP": results})
+        _patch_arxiv(monkeypatch, {"all:NLP": results})
 
         # Force "today" through the storage current_yymm, since the renderer's
         # date-now is purely cosmetic ("Updated on YYYY.MM.DD") and doesn't
@@ -204,7 +204,7 @@ class TestEndToEndPipeline:
                 entry_id="http://arxiv.org/abs/2604.00001v1",
             ),
         ]
-        _patch_arxiv(monkeypatch, {"NLP": results})
+        _patch_arxiv(monkeypatch, {"all:NLP": results})
         from nlp_arxiv_daily import storage
 
         monkeypatch.setattr(storage, "_current_yymm", lambda: "2604")


### PR DESCRIPTION
## Summary
- #62 후속 근본 대응. arXiv rate limit(429/503) 연속 실패 대응의 두 번째 단계.
- `core.py`의 쿼리 생성에서 각 필터 term에 명시적 `all:` 필드 prefix를 붙인다. 예: `NLP OR "Natural Language Processing"` → `all:NLP OR all:"Natural Language Processing"`.
- bare term은 arXiv 쿼리 파서가 필드/그룹핑을 추정하게 두는데, OR 절이 잘못 묶이면 조용히 엉뚱한 결과(혹은 0건)를 반환하고 그게 429 재시도 폭주로 이어졌다. `all:`로 고정하면 파싱이 결정적이 된다.
- **요청 수는 그대로**(키워드당 1쿼리). 요청량 감소가 아니라 정확도/견고성 개선이다.

## Notes / 한계
- 로컬 IP가 현재 arXiv에 throttle 중이라 새 쿼리 형식의 **라이브 200 응답 검증은 못 했다**. 단 `all:`은 arXiv API 공식 필드 prefix라 문법 문제는 없다. 머지 후 cron(또는 `workflow_dispatch`) 첫 run으로 실제 확인 권장.

## Test plan
- [x] `TestLoadConfig` 기대값을 `all:` prefix 형태로 갱신 (multi-word/single-word 2케이스), TDD 실패→구현→통과
- [x] 쿼리 문자열을 키로 stub하는 e2e 테스트의 stub 키도 `all:NLP`로 갱신
- [x] 전체 139 passed, coverage 94.8%, ruff check/format 통과
- [ ] (머지 후) 첫 cron run에서 arXiv 200 응답 및 키워드 결과 정상 수집 확인