### PR TITLE
Add opt-in AdSense injection via build env var

### DIFF
--- a/.github/workflows/astro-build.yml
+++ b/.github/workflows/astro-build.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Build
         env:
           NODE_ENV: production
+          # Repo variable — not inherited by forks, so forks build ad-free.
+          PUBLIC_ADSENSE_CLIENT: ${{ vars.ADSENSE_CLIENT }}
         run: pnpm build
 
       - name: Upload Pages artifact

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ uv run python -m nlp_arxiv_daily backfill --start 2024-01 --end 2025-12
 
 Idempotent — safe to re-run.
 
+### 6. (Optional) Serve AdSense ads
+
+The layout injects the AdSense script only when `PUBLIC_ADSENSE_CLIENT` is set at build time. Add a repository variable (**Settings → Secrets and variables → Actions → Variables**) named `ADSENSE_CLIENT` with your publisher ID (e.g. `ca-pub-XXXXXXXXXXXXXXXX`) — the build workflow passes it through. Without it the site builds ad-free.
+
 ## Local development
 
 Requires Python 3.13+ and Node 22+. The repo uses [`uv`](https://docs.astral.sh/uv/) and [`pnpm`](https://pnpm.io/).

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -25,6 +25,10 @@ const ogImage = new URL(
   Astro.site,
 ).toString();
 const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+
+// AdSense is opt-in: only injected when PUBLIC_ADSENSE_CLIENT is set at
+// build time (a CI repo variable, not committed), so forks build ad-free.
+const adsenseClient = import.meta.env.PUBLIC_ADSENSE_CLIENT;
 ---
 
 <!doctype html>
@@ -55,6 +59,19 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
       title="NLP Arxiv Daily"
       href={new URL(`${import.meta.env.BASE_URL.replace(/\/$/, "")}/rss.xml`, Astro.site).toString()}
     />
+    {
+      adsenseClient && (
+        <>
+          <meta name="google-adsense-account" content={adsenseClient} />
+          <script
+            is:inline
+            async
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClient}`}
+            crossorigin="anonymous"
+          />
+        </>
+      )
+    }
     <!-- Pre-paint theme bootstrap. Reads stored preference, falls back to
          system pref, sets the .dark class before first paint to avoid FOUC.
          is:inline so Astro doesn't bundle it as a deferred module. -->


### PR DESCRIPTION
## Summary

- Inject the AdSense head script (`adsbygoogle.js` + `google-adsense-account` meta) only when `PUBLIC_ADSENSE_CLIENT` is set at build time
- Pass the value from a repository Actions variable (`ADSENSE_CLIENT`) in the build workflow — repo variables are **not inherited by forks**, so forked deployments keep building ad-free with zero changes
- Document the opt-in step in the fork guide (README §6)

No publisher ID is committed to the repo. `ads.txt` is intentionally not added here — AdSense only reads it from the domain root, which is served by the root site.

## Test plan

Verified all three build scenarios locally (`NODE_ENV=production`, 107 pages each):

- [x] Env var unset → 0 pages contain the AdSense script
- [x] Env var empty string (mimics unset repo variable in CI) → 0 pages, build succeeds
- [x] Env var set to a `ca-pub-…` ID → all 107 pages contain the meta + script tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)