### PR TITLE
Move integration tests out of PR CI

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,6 +1,16 @@
 name: check-lint
 
-on: [pull_request]
+# Python lint/lock checks — skip web-only PRs.
+on:
+  pull_request:
+    paths:
+      - "nlp_arxiv_daily/**"
+      - "daily_arxiv.py"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - ".github/workflows/check-lint.yml"
 
 jobs:
   check-lint:

--- a/.github/workflows/nlp-arxiv-daily.yml
+++ b/.github/workflows/nlp-arxiv-daily.yml
@@ -45,3 +45,17 @@ jobs:
           rebase: "true"
           name: ${{ env.GITHUB_USER_NAME }}
           email: ${{ env.GITHUB_USER_EMAIL }}
+
+      # This cron doubles as the integration test against the real arXiv/HF
+      # APIs (PR CI runs unit tests only), so a failure here is the signal
+      # that the external contract broke — make it loud. No-op when the
+      # webhook secret is absent (forks).
+      - name: Notify Discord on failure
+        if: failure()
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          [ -z "$WEBHOOK_URL" ] && exit 0
+          curl -sf -H "Content-Type: application/json" \
+            -d "{\"content\":\"🚨 **nlp-arxiv-daily cron failed** — arXiv/HF fetch pipeline broke.\\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            "$WEBHOOK_URL"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,21 @@
 name: test
 
-on: [pull_request]
+# Unit tests only. Integration tests (real arXiv/HF calls) are NOT run here:
+# GH-Actions egress IPs share arxiv's per-IP 429 throttle with the rest of
+# GitHub, so they fail for reasons unrelated to the PR. The daily cron
+# (nlp-arxiv-daily.yml) exercises the real APIs and alerts on failure;
+# run `make test-integration` locally for the contract smoke.
+on:
+  pull_request:
+    paths:
+      - "nlp_arxiv_daily/**"
+      - "daily_arxiv.py"
+      - "tests/**"
+      - "config.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+      - ".github/workflows/test.yml"
 
 jobs:
   test:
@@ -20,6 +35,3 @@ jobs:
 
       - name: Run unit tests
         run: make test
-
-      - name: Run integration tests
-        run: make test-integration

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ make set-dev
 uv run python -m nlp_arxiv_daily run        # fetch + persist JSON
 uv run python -m nlp_arxiv_daily fetch      # fetch only
 make test                                   # run unit tests
+make test-integration                       # real arXiv/HF smoke (not run in PR CI)
 make quality                                # ruff lint + format
 
 # website


### PR DESCRIPTION
## Summary

PR-time integration tests call the real arXiv API from shared GitHub-Actions egress IPs, which arXiv throttles per-IP (HTTP 429) no matter how polite our request rate is — so they fail for reasons unrelated to the change under review (see #64's `test` check). External-contract breakage correlates with time, not with PRs, so the signal is moved to where real traffic already flows:

- **test.yml** — unit tests only, triggered only when Python-side paths change (web-only PRs skip it entirely)
- **check-lint.yml** — same paths filter
- **nlp-arxiv-daily.yml** — the daily cron already exercises the real arXiv/HF pipeline twice a day, making it the de facto integration test
- **README** — documents `make test-integration` for running the contract smoke locally

The integration tests themselves are kept in the repo for local use.

## Test plan

- [x] `make test` locally: 139 passed (2 integration deselected), coverage 94.84%
- [x] All three workflow files parse as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)