### PR TITLE
fix: stop oversized ad units from widening the page

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -45,3 +45,21 @@ html.dark {
 body {
   transition: background-color 150ms ease, color 150ms ease;
 }
+
+/* AdSense auto ads occasionally render a unit that ignores the width of the
+   slot it was placed in. When a slot goes unfilled (`data-ad-status=unfilled`)
+   Google drops in a "Discover more" fallback that lays itself out at a fixed
+   1200px — measured live, that is its own capped width, and it renders at
+   exactly 1200px in the full-width body-level slot too. Inside <main>, whose
+   content box is 720px, the extra 480px pushed the document from 1385px to
+   1533px and gave the whole page a horizontal scrollbar. Reproduced in 1 of 8
+   cold loads; a reload usually serves a different unit, which is why it looked
+   random.
+
+   `clip` rather than `hidden` on purpose: `hidden` would turn <main> into a
+   scroll container, which breaks the `scroll-mt-20` anchor offsets the table
+   of contents relies on. `clip` just clips. Safari <16 ignores it and keeps
+   today's behaviour, which is an acceptable floor. */
+main {
+  overflow-x: clip;
+}


### PR DESCRIPTION
## Summary

- On first load the page intermittently grew a horizontal scrollbar, with an ad hanging off the right edge of the content column. A reload usually cleared it, so it looked random.
- Measured cause: when an auto-ad slot goes unfilled (`data-ad-status=unfilled`), AdSense substitutes a "Discover more" unit that lays itself out at a fixed **1200px**, ignoring the 720px slot it landed in. The extra 480px pushed the document from 1385px to 1533px.
- 1200px is that unit's own capped width rather than anything we ask for — it renders at exactly 1200px in the full-width body-level slot too, where it fits fine. There is no console switch for it: the related search format that used to be togglable was retired on 2026-08-06, and ad intent is already off. Containing it is the only lever left.
- `main { overflow-x: clip }`, which is what the other site on this domain already does — and why the same ad never breaks its layout.

`clip` rather than `hidden` on purpose: `hidden` would turn `<main>` into a scroll container and break the `scroll-mt-20` anchor offsets the table of contents relies on. Safari <16 ignores `clip` and keeps today's behaviour, which is an acceptable floor.

## Test plan

- [x] `astro build` — 108 pages, pagefind index intact
- [x] Reproduced the failure exactly against the built site at 1400px via CDP, injecting a 1200px box as the first child of `<main>` (`x=333, w=1200, right=1533` — the geometry captured live)

      before   scrollWidth 1385 → 1533, horizontal scrollbar present
      after    scrollWidth 1385 → 1385, none

- [x] Anchor offsets (`scroll-mt-20`) still move the viewport in both the patched and control runs, confirming `clip` did not create a scroll container
- [x] index / archive / a month page / search at 1400px and 390px: zero real elements clipped by the new rule
- [x] Live measurement that motivated this: 8 isolated cold loads of the deployed site reproduced `scrollWidth=1533` once; the offending node was `div#aswift_1_host` (w=1200) inside a 720px `ins.adsbygoogle`
- [ ] After deploy: repeat the cold-load loop against the live site and confirm `scrollWidth == clientWidth` throughout, and that filled ads still render at 720px

## Note

This clips the overflowing part of a mis-sized unit. It only ever applies to the unfilled-slot substitute — correctly served ads all render within 720px — so ad impressions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y7CJ8neCy2jQeCDBgGFZD