### PR TITLE
Revert "fix: stop oversized ad units from widening the page"

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -45,21 +45,3 @@ html.dark {
 body {
   transition: background-color 150ms ease, color 150ms ease;
 }
-
-/* AdSense auto ads occasionally render a unit that ignores the width of the
-   slot it was placed in. When a slot goes unfilled (`data-ad-status=unfilled`)
-   Google drops in a "Discover more" fallback that lays itself out at a fixed
-   1200px — measured live, that is its own capped width, and it renders at
-   exactly 1200px in the full-width body-level slot too. Inside <main>, whose
-   content box is 720px, the extra 480px pushed the document from 1385px to
-   1533px and gave the whole page a horizontal scrollbar. Reproduced in 1 of 8
-   cold loads; a reload usually serves a different unit, which is why it looked
-   random.
-
-   `clip` rather than `hidden` on purpose: `hidden` would turn <main> into a
-   scroll container, which breaks the `scroll-mt-20` anchor offsets the table
-   of contents relies on. `clip` just clips. Safari <16 ignores it and keeps
-   today's behaviour, which is an acceptable floor. */
-main {
-  overflow-x: clip;
-}


### PR DESCRIPTION
## Summary

Reverts #66 (`bc2be4b`).

Clipping `<main>` stopped the page from growing a horizontal scrollbar, but it did so by cutting a served ad off mid-sentence at the column edge. Seen live that reads as a rendering bug, and truncating an ad that filled normally is the kind of thing the AdSense policies are about. Trading a broken-looking page for a broken-looking ad is not an improvement, and the ad is the worse half of that trade.

## What this leaves

The underlying problem is unchanged: Google sometimes renders a 1200px unit into the 720px slot inside `<main>`, roughly 1 cold load in 8, and the page grows a horizontal scrollbar when it happens.

No CSS on our side fixes that cleanly:

| approach | outcome |
|---|---|
| clip at the column | ad cut mid-content (what this reverts) |
| clip at the viewport | ad cut at the screen edge |
| allow the overflow | page scrolls horizontally (status quo) |
| full-bleed container | resizes every other ad too |
| hide or scale from JS | explicitly against the ad policies |

Fixing it properly means stopping that unit from being served, which needs the format identified first. Next step is turning Multiplex off for a day and checking whether the oversized `goog-rentries` grid stops appearing — the console describes Multiplex as a native grid format, and the oversized unit renders as `google-aiuf > goog-rentries > goog-rentry`, drawn into the parent document rather than into a sized iframe the way banner ads are.

## Test plan

- [x] `astro build` — 108 pages, pagefind index intact
- [x] `overflow-x:clip` no longer present in the built CSS
- [ ] After deploy: confirm the ad renders whole again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y7CJ8neCy2jQeCDBgGFZD