### PR TITLE
feat: BibTeX export and Zotero COinS metadata on list pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 - 🏷️ **Keyword tabs** — NLP, LLM, RAG, Reasoning, Multimodal, Long Context, Code LLM, …
 - 🗓️ **Monthly archives** going back to launch
 - 📡 **[RSS feed](https://monologg.kr/nlp-arxiv-daily/rss.xml)** for your reader of choice
+- 📥 **BibTeX export** — per paper (copy button), per keyword, or the whole page / month as one `.bib` file (e.g. [`/bibtex/all.bib`](https://monologg.kr/nlp-arxiv-daily/bibtex/all.bib), `/bibtex/rag.bib`, `/archive/2026-08/all.bib`)
+- 🗂️ **Zotero-ready** — every list page embeds [COinS](https://en.wikipedia.org/wiki/COinS) metadata, so the Zotero connector can save all papers on a page in one click (as Preprint items with DOI, URL, and the keyword as a tag)
 - 🌓 Light/dark theme, mobile-friendly, no tracking
 
 ## How it works

--- a/web/src/components/KeywordFilter.astro
+++ b/web/src/components/KeywordFilter.astro
@@ -1,4 +1,6 @@
 ---
+import { keywordSlug } from "../utils/keyword.ts";
+
 interface Props {
   keywords: string[];
 }
@@ -20,7 +22,7 @@ const { keywords } = Astro.props;
     All
   </button>
   {keywords.map((keyword) => {
-    const slug = keyword.toLowerCase().replace(/\s+/g, "-");
+    const slug = keywordSlug(keyword);
     return (
       <button
         type="button"

--- a/web/src/components/KeywordSection.astro
+++ b/web/src/components/KeywordSection.astro
@@ -1,23 +1,42 @@
 ---
 import PaperCard from "./PaperCard.astro";
 import { sortPapersDesc } from "../utils/paperRow.ts";
+import { keywordSlug } from "../utils/keyword.ts";
+import { withBase } from "../utils/url.ts";
 
 interface Props {
   keyword: string;
   papers: Record<string, string>;
+  /** Directory holding this dataset's `.bib` files, e.g. "/bibtex" for the
+   * Latest page or "/archive/2026-08" for a month. Omit to hide the link. */
+  bibDir?: string;
 }
 
-const { keyword, papers } = Astro.props;
-const slug = keyword.toLowerCase().replace(/\s+/g, "-");
+const { keyword, papers, bibDir } = Astro.props;
+const slug = keywordSlug(keyword);
 const ordered = sortPapersDesc(papers);
+const bibHref = bibDir ? withBase(`${bibDir}/${slug}.bib`) : null;
 ---
 
 <section id={slug} class="mb-12 scroll-mt-20">
   <header class="flex items-baseline justify-between mb-3 pb-2 border-b border-(--color-muted)/30">
     <h2 class="text-2xl font-semibold">{keyword}</h2>
-    <span class="text-(--color-muted) text-sm">{ordered.length} paper{ordered.length === 1 ? "" : "s"}</span>
+    <span class="text-(--color-muted) text-sm flex items-center gap-3">
+      <span>{ordered.length} paper{ordered.length === 1 ? "" : "s"}</span>
+      {bibHref && (
+        <a
+          class="text-(--color-accent) hover:underline"
+          href={bibHref}
+          download
+          title={`Download all ${keyword} papers as BibTeX`}
+          data-pagefind-ignore
+        >
+          .bib
+        </a>
+      )}
+    </span>
   </header>
   {ordered.map(([paperId, row]) => (
-    <PaperCard paperId={paperId} row={row} />
+    <PaperCard paperId={paperId} row={row} keyword={keyword} />
   ))}
 </section>

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -1,13 +1,19 @@
 ---
 import { parsePaperRow } from "../utils/paperRow.ts";
+import { paperBibtex } from "../utils/bibtex.ts";
+import { coinsTitle } from "../utils/coins.ts";
 
 interface Props {
   paperId: string;
   row: string;
+  /** Keyword section the card sits in — becomes a Zotero tag via COinS. */
+  keyword?: string;
 }
 
-const { paperId, row } = Astro.props;
+const { paperId, row, keyword } = Astro.props;
 const parsed = parsePaperRow(row);
+const bibtex = parsed ? paperBibtex(paperId, parsed) : null;
+const coins = parsed ? coinsTitle(paperId, parsed, keyword) : null;
 ---
 
 {parsed ? (
@@ -52,10 +58,47 @@ const parsed = parsePaperRow(row);
           code
         </a>
       )}
+      <button
+        type="button"
+        class="text-(--color-accent) hover:underline cursor-pointer"
+        data-bibtex={bibtex}
+        title="Copy BibTeX entry"
+        aria-label={`Copy BibTeX for ${parsed.title}`}
+        data-pagefind-ignore
+      >
+        bibtex
+      </button>
     </div>
+    {/* COinS: lets the Zotero connector save every paper on the page.
+        Zero-size span by design — Zotero reads the title attribute only. */}
+    <span class="Z3988" title={coins} aria-hidden="true" data-pagefind-ignore></span>
   </article>
 ) : (
   <article class="py-3 border-b border-(--color-muted)/15 last:border-b-0 text-(--color-muted) text-sm">
     <span>{paperId}</span> — unparseable row
   </article>
 )}
+
+<script>
+  // One delegated listener for every card's "bibtex" button. Astro hoists
+  // this script once per page regardless of how many cards render.
+  const RESET_MS = 1500;
+  document.addEventListener("click", async (event) => {
+    const btn = (event.target as HTMLElement).closest<HTMLButtonElement>("button[data-bibtex]");
+    if (!btn) return;
+    const text = btn.dataset.bibtex ?? "";
+    const label = btn.textContent;
+    try {
+      await navigator.clipboard.writeText(text);
+      btn.textContent = "copied";
+    } catch {
+      // Clipboard API unavailable (insecure context, old browser) — show
+      // the entry so the reader can copy it by hand.
+      window.prompt("Copy BibTeX:", text);
+      return;
+    }
+    window.setTimeout(() => {
+      btn.textContent = label;
+    }, RESET_MS);
+  });
+</script>

--- a/web/src/components/TableOfContents.astro
+++ b/web/src/components/TableOfContents.astro
@@ -1,4 +1,6 @@
 ---
+import { keywordSlug } from "../utils/keyword.ts";
+
 interface Props {
   keywords: Array<[string, Record<string, string>]>;
 }
@@ -12,7 +14,7 @@ const { keywords } = Astro.props;
   </h2>
   <ul class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
     {keywords.map(([keyword, papers]) => {
-      const slug = keyword.toLowerCase().replace(/\s+/g, "-");
+      const slug = keywordSlug(keyword);
       return (
         <li>
           <a class="text-(--color-accent) hover:underline" href={`#${slug}`}>

--- a/web/src/pages/archive/[month].astro
+++ b/web/src/pages/archive/[month].astro
@@ -22,6 +22,7 @@ const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
   0,
 );
+const bibDir = `/archive/${entry.id}`;
 ---
 
 <Layout
@@ -41,13 +42,20 @@ const totalPapers = keywords.reduce(
       <p class="text-(--color-muted) text-sm">
         {totalPapers} papers across {keywords.length} keywords.
       </p>
+      {keywords.length > 0 && (
+        <p class="text-(--color-muted) text-sm mt-1">
+          <a class="text-(--color-accent) hover:underline" href={withBase(`${bibDir}/all.bib`)} download>
+            Download all as BibTeX
+          </a>
+        </p>
+      )}
     </header>
 
     {keywords.length > 0 ? (
       <>
         <TableOfContents keywords={keywords} />
         {keywords.map(([keyword, papers]) => (
-          <KeywordSection keyword={keyword} papers={papers} />
+          <KeywordSection keyword={keyword} papers={papers} bibDir={bibDir} />
         ))}
       </>
     ) : (

--- a/web/src/pages/archive/[month]/[slug].bib.ts
+++ b/web/src/pages/archive/[month]/[slug].bib.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { buildBib } from "../../../utils/bibtex.ts";
+import { keywordSlug } from "../../../utils/keyword.ts";
+import { nonEmptyKeywords, type KeywordEntries } from "../../../utils/papers.ts";
+
+/**
+ * /archive/<YYYY-MM>/<keyword-slug>.bib — one keyword section of a month.
+ * /archive/<YYYY-MM>/all.bib          — the whole month, de-duplicated.
+ */
+export async function getStaticPaths() {
+  const entries = await getCollection("archive");
+  return entries.flatMap((entry) => {
+    const keywords = nonEmptyKeywords(entry.data);
+    const paths = keywords.map(([keyword, papers]) => ({
+      params: { month: entry.id, slug: keywordSlug(keyword) },
+      props: { buckets: [[keyword, papers]] as KeywordEntries, header: `NLP Arxiv Daily — ${keyword} (${entry.id})` },
+    }));
+    paths.push({
+      params: { month: entry.id, slug: "all" },
+      props: { buckets: keywords, header: `NLP Arxiv Daily — all keywords (${entry.id})` },
+    });
+    return paths;
+  });
+}
+
+export const GET: APIRoute = ({ props }) => {
+  const { buckets, header } = props as { buckets: KeywordEntries; header: string };
+  return new Response(buildBib(buckets, header), {
+    headers: { "Content-Type": "application/x-bibtex; charset=utf-8" },
+  });
+};

--- a/web/src/pages/bibtex/[slug].bib.ts
+++ b/web/src/pages/bibtex/[slug].bib.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from "astro";
+import { buildBib } from "../../utils/bibtex.ts";
+import { keywordSlug } from "../../utils/keyword.ts";
+import { resolveLatest, type KeywordEntries } from "../../utils/papers.ts";
+
+/**
+ * /bibtex/<keyword-slug>.bib — every paper in one "Latest" keyword section.
+ * /bibtex/all.bib          — the whole Latest page, de-duplicated.
+ */
+export async function getStaticPaths() {
+  const { keywords, fallbackMonth } = await resolveLatest();
+  const label = fallbackMonth ?? "latest";
+  const paths = keywords.map(([keyword, papers]) => ({
+    params: { slug: keywordSlug(keyword) },
+    props: { buckets: [[keyword, papers]] as KeywordEntries, header: `NLP Arxiv Daily — ${keyword} (${label})` },
+  }));
+  paths.push({
+    params: { slug: "all" },
+    props: { buckets: keywords, header: `NLP Arxiv Daily — all keywords (${label})` },
+  });
+  return paths;
+}
+
+export const GET: APIRoute = ({ props }) => {
+  const { buckets, header } = props as { buckets: KeywordEntries; header: string };
+  return new Response(buildBib(buckets, header), {
+    headers: { "Content-Type": "application/x-bibtex; charset=utf-8" },
+  });
+};

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -3,46 +3,17 @@ import Layout from "../layouts/Layout.astro";
 import KeywordFilter from "../components/KeywordFilter.astro";
 import KeywordSection from "../components/KeywordSection.astro";
 import TableOfContents from "../components/TableOfContents.astro";
-import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
-import { paperBucketSchema } from "../content.config.ts";
 import { withBase } from "../utils/url.ts";
-import { getCollection } from "astro:content";
+import { resolveLatest } from "../utils/papers.ts";
 
-const currentData = paperBucketSchema.parse(currentPapers);
-const currentKeywords = Object.entries(currentData).filter(
-  ([, papers]) => Object.keys(papers).length > 0,
-);
-
-let data = currentData;
-let keywords = currentKeywords;
-let fallbackMonth: string | null = null;
-
-if (currentKeywords.length === 0) {
-  const entries = await getCollection("archive");
-  const candidates = entries
-    .map((e) => ({
-      id: e.id,
-      data: e.data,
-      keywords: Object.entries(e.data).filter(
-        ([, papers]) => Object.keys(papers).length > 0,
-      ),
-    }))
-    .filter((c) => c.keywords.length > 0)
-    .sort((a, b) => b.id.localeCompare(a.id));
-
-  if (candidates.length > 0) {
-    const latest = candidates[0];
-    data = latest.data;
-    keywords = latest.keywords;
-    fallbackMonth = latest.id;
-  }
-}
+const { keywords, fallbackMonth } = await resolveLatest();
 
 const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
   0,
 );
 const today = new Date().toISOString().slice(0, 10);
+const bibDir = "/bibtex";
 ---
 
 <Layout title="NLP Arxiv Daily" current="home">
@@ -63,6 +34,14 @@ const today = new Date().toISOString().slice(0, 10);
           {totalPapers} papers across {keywords.length} keywords this month.
         </p>
       )}
+      {keywords.length > 0 && (
+        <p class="text-(--color-muted) text-sm mt-1">
+          <a class="text-(--color-accent) hover:underline" href={withBase(`${bibDir}/all.bib`)} download>
+            Download all as BibTeX
+          </a>
+          {" "}· every paper on this page is also visible to the Zotero connector.
+        </p>
+      )}
     </header>
 
     {keywords.length > 0 ? (
@@ -70,7 +49,7 @@ const today = new Date().toISOString().slice(0, 10);
         <KeywordFilter keywords={keywords.map(([k]) => k)} />
         <TableOfContents keywords={keywords} />
         {keywords.map(([keyword, papers]) => (
-          <KeywordSection keyword={keyword} papers={papers} />
+          <KeywordSection keyword={keyword} papers={papers} bibDir={bibDir} />
         ))}
       </>
     ) : (

--- a/web/src/utils/bibtex.ts
+++ b/web/src/utils/bibtex.ts
@@ -1,0 +1,121 @@
+import { parsePaperRow, type ParsedPaper } from "./paperRow.ts";
+
+/**
+ * BibTeX export.
+ *
+ * The pipeline only stores the first author, so entries carry
+ * `author = {First Author and others}` — BibTeX renders "and others" as
+ * "et al.", which is the honest representation of what we know. arXiv's own
+ * export (https://arxiv.org/bibtex/<id>) has the full list if a reader needs it.
+ */
+
+export interface BibEntry {
+  paperId: string;
+  paper: ParsedPaper;
+  /** Every keyword section this paper appeared under. */
+  keywords: string[];
+}
+
+const MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+
+// Words that make for a useless cite key ("the2026paper").
+const KEY_STOPWORDS = new Set(["a", "an", "the", "on", "of", "in", "to", "for", "and", "towards", "toward", "from", "with"]);
+
+function asciiToken(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+/** Google-Scholar-style key: `<lastname><year><firstTitleWord>`. */
+export function citeKey(paperId: string, paper: ParsedPaper): string {
+  const authorTokens = paper.firstAuthor.trim().split(/\s+/);
+  const last = asciiToken(authorTokens[authorTokens.length - 1] ?? "");
+  const year = paper.date.slice(0, 4);
+  const titleWord =
+    paper.title
+      .split(/\s+/)
+      .map(asciiToken)
+      .find((w) => w.length > 0 && !KEY_STOPWORDS.has(w)) ?? "";
+  const key = `${last}${year}${titleWord}`;
+  return key.length > 4 ? key : `arxiv${paperId.replace(/[^0-9a-z]/gi, "")}`;
+}
+
+/**
+ * Escape LaTeX-special characters in a title. Titles that already contain
+ * `$` are assumed to carry inline math and are passed through untouched —
+ * escaping `_`/`^` inside math would break it, and arXiv titles are LaTeX
+ * to begin with.
+ */
+export function escapeTitle(title: string): string {
+  if (title.includes("$")) return title;
+  return title.replace(/(?<!\\)([&%#_^])/g, "\\$1");
+}
+
+export function formatEntry(entry: BibEntry, key: string): string {
+  const { paperId, paper, keywords } = entry;
+  const year = paper.date.slice(0, 4);
+  const month = MONTHS[Number(paper.date.slice(5, 7)) - 1];
+  const fields: Array<[string, string]> = [
+    ["title", `{${escapeTitle(paper.title)}}`],
+    ["author", `{${paper.firstAuthor} and others}`],
+    ["year", `{${year}}`],
+    ["month", month ?? ""],
+    ["eprint", `{${paperId}}`],
+    ["archivePrefix", "{arXiv}"],
+    ["url", `{${paper.paperUrl}}`],
+  ];
+  if (paper.codeLink) fields.push(["note", `{Code: \\url{${paper.codeLink}}}`]);
+  if (keywords.length > 0) fields.push(["keywords", `{${keywords.join(", ")}}`]);
+
+  const width = Math.max(...fields.map(([k]) => k.length));
+  const body = fields
+    .filter(([, v]) => v.length > 0)
+    .map(([k, v]) => `  ${k.padEnd(width)} = ${v},`)
+    .join("\n");
+  return `@misc{${key},\n${body}\n}`;
+}
+
+/**
+ * Build a `.bib` document from keyword buckets. A paper matched by several
+ * keywords is emitted once, with all of them in its `keywords` field. Cite
+ * keys are de-duplicated with a/b/c suffixes.
+ */
+export function buildBib(buckets: Array<[string, Record<string, string>]>, header?: string): string {
+  const byId = new Map<string, BibEntry>();
+  for (const [keyword, papers] of buckets) {
+    for (const [paperId, row] of Object.entries(papers)) {
+      const existing = byId.get(paperId);
+      if (existing) {
+        existing.keywords.push(keyword);
+        continue;
+      }
+      const paper = parsePaperRow(row);
+      if (!paper) continue;
+      byId.set(paperId, { paperId, paper, keywords: [keyword] });
+    }
+  }
+
+  const entries = Array.from(byId.values()).sort((a, b) =>
+    a.paperId < b.paperId ? 1 : a.paperId > b.paperId ? -1 : 0,
+  );
+
+  const seen = new Map<string, number>();
+  const blocks = entries.map((entry) => {
+    const base = citeKey(entry.paperId, entry.paper);
+    const n = seen.get(base) ?? 0;
+    seen.set(base, n + 1);
+    const key = n === 0 ? base : `${base}${String.fromCharCode(96 + n)}`;
+    return formatEntry(entry, key);
+  });
+
+  const preamble = header ? `% ${header}\n% ${entries.length} entries\n\n` : "";
+  return preamble + blocks.join("\n\n") + "\n";
+}
+
+/** Single-paper BibTeX for the per-card copy button. */
+export function paperBibtex(paperId: string, paper: ParsedPaper): string {
+  return formatEntry({ paperId, paper, keywords: [] }, citeKey(paperId, paper));
+}

--- a/web/src/utils/coins.ts
+++ b/web/src/utils/coins.ts
@@ -1,0 +1,31 @@
+import type { ParsedPaper } from "./paperRow.ts";
+
+/**
+ * COinS (ContextObjects in Spans) descriptor for one paper.
+ *
+ * Zotero's connector scans a page for `<span class="Z3988" title="...">`
+ * and offers every match in its multi-select save dialog — the only way
+ * to make a *list* page importable, since Highwire `citation_*` meta
+ * tags describe a single item per page.
+ *
+ * Field choices follow zotero/utilities openurl.js `parseContextObject`:
+ *  - `mtx:dc` + `rft.type=preprint` → Zotero "Preprint" item
+ *  - `rft.creator` → author, `rft.date` → date, `rft.source` → repository
+ *  - `rft_id=info:doi/…` → DOI (every arXiv paper has a DataCite DOI)
+ *  - `rft_id=https://…` → URL, `rft.subject` → tag
+ */
+export function coinsTitle(paperId: string, paper: ParsedPaper, keyword?: string): string {
+  const parts: Array<[string, string]> = [
+    ["ctx_ver", "Z39.88-2004"],
+    ["rft_val_fmt", "info:ofi/fmt:kev:mtx:dc"],
+    ["rft.type", "preprint"],
+    ["rft.title", paper.title],
+    ["rft.creator", paper.firstAuthor],
+    ["rft.date", paper.date],
+    ["rft.source", "arXiv"],
+    ["rft_id", `info:doi/10.48550/arXiv.${paperId}`],
+    ["rft_id", paper.paperUrl],
+  ];
+  if (keyword) parts.push(["rft.subject", keyword]);
+  return parts.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join("&");
+}

--- a/web/src/utils/keyword.ts
+++ b/web/src/utils/keyword.ts
@@ -1,0 +1,7 @@
+/**
+ * Keyword → URL/anchor slug. Single source of truth so section anchors,
+ * the filter pills, and the `.bib` download routes always agree.
+ */
+export function keywordSlug(keyword: string): string {
+  return keyword.toLowerCase().replace(/\s+/g, "-");
+}

--- a/web/src/utils/papers.ts
+++ b/web/src/utils/papers.ts
@@ -1,0 +1,44 @@
+import { getCollection } from "astro:content";
+import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
+import { paperBucketSchema } from "../content.config.ts";
+
+export type PaperBucket = Record<string, Record<string, string>>;
+export type KeywordEntries = Array<[string, Record<string, string>]>;
+
+export function nonEmptyKeywords(data: PaperBucket): KeywordEntries {
+  return Object.entries(data).filter(([, papers]) => Object.keys(papers).length > 0);
+}
+
+export interface LatestSnapshot {
+  data: PaperBucket;
+  keywords: KeywordEntries;
+  /** Set when the current-month JSON was empty and we fell back to the
+   * newest non-empty archive month. */
+  fallbackMonth: string | null;
+}
+
+/**
+ * The "Latest" dataset: the current-month JSON, or — early in a month before
+ * the cron has landed anything — the newest non-empty archive snapshot.
+ * Shared by the index page and the BibTeX endpoints so both agree on what
+ * "latest" means.
+ */
+export async function resolveLatest(): Promise<LatestSnapshot> {
+  const currentData = paperBucketSchema.parse(currentPapers);
+  const currentKeywords = nonEmptyKeywords(currentData);
+  if (currentKeywords.length > 0) {
+    return { data: currentData, keywords: currentKeywords, fallbackMonth: null };
+  }
+
+  const entries = await getCollection("archive");
+  const candidates = entries
+    .map((e) => ({ id: e.id, data: e.data, keywords: nonEmptyKeywords(e.data) }))
+    .filter((c) => c.keywords.length > 0)
+    .sort((a, b) => b.id.localeCompare(a.id));
+
+  if (candidates.length === 0) {
+    return { data: currentData, keywords: [], fallbackMonth: null };
+  }
+  const latest = candidates[0];
+  return { data: latest.data, keywords: latest.keywords, fallbackMonth: latest.id };
+}


### PR DESCRIPTION
## Summary
- Add static BibTeX endpoints: `/bibtex/<keyword>.bib`, `/bibtex/all.bib`, `/archive/<YYYY-MM>/<keyword>.bib`, `/archive/<YYYY-MM>/all.bib`. `all.bib` de-duplicates papers matched by several keywords and merges them into a `keywords` field; cite keys are `<lastname><year><firstTitleWord>` with a/b suffixes on collision.
- Add "Download all as BibTeX" in page headers, a `.bib` link on every keyword section, and a copy-to-clipboard `bibtex` button on every paper card.
- Embed a COinS `<span class="Z3988">` per paper card so the Zotero connector can save every paper on a list page. Fields were checked against Zotero's `openurl.js` parser: Dublin Core + `rft.type=preprint` → Preprint item, DataCite DOI (`10.48550/arXiv.<id>`), arXiv URL, date, first author, and the keyword as a tag.
- Refactor: single `keywordSlug()` shared by sections, filter pills, TOC and the new routes; the index page's "fall back to newest archive month" logic moves into `resolveLatest()` so the `.bib` endpoints agree with the page.

Known limitation: the pipeline stores only the first author, so entries use `author = {First Author and others}` and Zotero items get one author. Full author lists need a fetcher/storage change (follow-up).

## Test plan
- [x] `NODE_ENV=production astro build` passes; 24 `.bib` files under `dist/bibtex/`, per-month files under `dist/archive/<month>/`
- [x] `all.bib` has 477 unique entries for the current month, no duplicate cite keys
- [x] Math titles (`$...$`) pass through unescaped; `_`/`&` in plain titles are escaped
- [x] Old pipe-format archive rows (e.g. 2024-08) export correctly
- [x] TOC anchors, filter pills and section ids still match after the slug refactor
- [ ] On the deployed preview: click `bibtex` on a card → clipboard gets the entry, label flips to "copied"
- [ ] With the Zotero connector installed, open the Latest page → folder icon appears and the multi-select dialog lists all papers as Preprints with DOI/URL/tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
