### PR TITLE
feat: per-keyword RSS feeds at /rss/<keyword>.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - 🔎 **Full-text search** across every paper (powered by [Pagefind](https://pagefind.app))
 - 🏷️ **Keyword tabs** — NLP, LLM, RAG, Reasoning, Multimodal, Long Context, Code LLM, …
 - 🗓️ **Monthly archives** going back to launch
-- 📡 **[RSS feed](https://monologg.kr/nlp-arxiv-daily/rss.xml)** for your reader of choice
+- 📡 **[RSS feed](https://monologg.kr/nlp-arxiv-daily/rss.xml)** for your reader of choice — plus one feed per keyword (e.g. [`/rss/rag.xml`](https://monologg.kr/nlp-arxiv-daily/rss/rag.xml), `/rss/llm-agent.xml`)
 - 📥 **BibTeX export** — per paper (copy button), per keyword, or the whole page / month as one `.bib` file (e.g. [`/bibtex/all.bib`](https://monologg.kr/nlp-arxiv-daily/bibtex/all.bib), `/bibtex/rag.bib`, `/archive/2026-08/all.bib`)
 - 🗂️ **Zotero-ready** — every list page embeds [COinS](https://en.wikipedia.org/wiki/COinS) metadata, so the Zotero connector can save all papers on a page in one click (as Preprint items with DOI, URL, and the keyword as a tag)
 - 🌓 Light/dark theme, mobile-friendly, no tracking

--- a/web/src/components/KeywordSection.astro
+++ b/web/src/components/KeywordSection.astro
@@ -10,12 +10,16 @@ interface Props {
   /** Directory holding this dataset's `.bib` files, e.g. "/bibtex" for the
    * Latest page or "/archive/2026-08" for a month. Omit to hide the link. */
   bibDir?: string;
+  /** Show the per-keyword RSS link (Latest page only — archive months are
+   * frozen, so a feed for them would never update). */
+  rss?: boolean;
 }
 
-const { keyword, papers, bibDir } = Astro.props;
+const { keyword, papers, bibDir, rss = false } = Astro.props;
 const slug = keywordSlug(keyword);
 const ordered = sortPapersDesc(papers);
 const bibHref = bibDir ? withBase(`${bibDir}/${slug}.bib`) : null;
+const rssHref = rss ? withBase(`/rss/${slug}.xml`) : null;
 ---
 
 <section id={slug} class="mb-12 scroll-mt-20">
@@ -32,6 +36,16 @@ const bibHref = bibDir ? withBase(`${bibDir}/${slug}.bib`) : null;
           data-pagefind-ignore
         >
           .bib
+        </a>
+      )}
+      {rssHref && (
+        <a
+          class="text-(--color-accent) hover:underline"
+          href={rssHref}
+          title={`RSS feed for ${keyword}`}
+          data-pagefind-ignore
+        >
+          rss
         </a>
       )}
     </span>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -39,6 +39,7 @@ const bibDir = "/bibtex";
           <a class="text-(--color-accent) hover:underline" href={withBase(`${bibDir}/all.bib`)} download>
             Download all as BibTeX
           </a>
+          {" "}· <a class="text-(--color-accent) hover:underline" href={withBase("/rss.xml")}>RSS</a> (each keyword has its own feed, see section headers)
           {" "}· every paper on this page is also visible to the Zotero connector.
         </p>
       )}
@@ -49,7 +50,7 @@ const bibDir = "/bibtex";
         <KeywordFilter keywords={keywords.map(([k]) => k)} />
         <TableOfContents keywords={keywords} />
         {keywords.map(([keyword, papers]) => (
-          <KeywordSection keyword={keyword} papers={papers} bibDir={bibDir} />
+          <KeywordSection keyword={keyword} papers={papers} bibDir={bibDir} rss />
         ))}
       </>
     ) : (

--- a/web/src/pages/rss.xml.ts
+++ b/web/src/pages/rss.xml.ts
@@ -1,45 +1,13 @@
-import rss from "@astrojs/rss";
 import type { APIContext } from "astro";
-import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
-import { paperBucketSchema } from "../content.config.ts";
-import { parsePaperRow } from "../utils/paperRow.ts";
+import { buildFeedItems, feedResponse } from "../utils/feed.ts";
+import { resolveLatest } from "../utils/papers.ts";
 
-interface FeedItem {
-  title: string;
-  link: string;
-  pubDate: Date;
-  description: string;
-  customData: string;
-}
-
+/** /rss.xml — every keyword. Per-keyword feeds live at /rss/<slug>.xml. */
 export async function GET(context: APIContext) {
-  const data = paperBucketSchema.parse(currentPapers);
-
-  const items: FeedItem[] = [];
-  for (const [keyword, papers] of Object.entries(data)) {
-    for (const [paperId, row] of Object.entries(papers)) {
-      const parsed = parsePaperRow(row);
-      if (!parsed) continue;
-      items.push({
-        title: parsed.title,
-        link: parsed.paperUrl,
-        pubDate: new Date(parsed.date),
-        description: `${parsed.firstAuthor} et al. — arxiv:${paperId} — ${keyword}`,
-        customData: `<category>${keyword}</category>`,
-      });
-    }
-  }
-  // Newest first.
-  items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
-
-  // The channel <link> should point at the actual home page, which lives
-  // under the base path (/nlp-arxiv-daily/) — Astro.site by itself drops it.
-  const homeUrl = new URL(import.meta.env.BASE_URL, context.site!).toString();
-
-  return rss({
+  const { keywords } = await resolveLatest();
+  return feedResponse(context, {
     title: "NLP Arxiv Daily",
     description: "Daily-refreshed NLP arxiv paper digest",
-    site: homeUrl,
-    items,
+    items: buildFeedItems(keywords),
   });
 }

--- a/web/src/pages/rss/[slug].xml.ts
+++ b/web/src/pages/rss/[slug].xml.ts
@@ -1,0 +1,22 @@
+import type { APIContext } from "astro";
+import { buildFeedItems, feedResponse } from "../../utils/feed.ts";
+import { keywordSlug } from "../../utils/keyword.ts";
+import { resolveLatest, type KeywordEntries } from "../../utils/papers.ts";
+
+/** /rss/<keyword-slug>.xml — one keyword section of the Latest page. */
+export async function getStaticPaths() {
+  const { keywords } = await resolveLatest();
+  return keywords.map(([keyword, papers]) => ({
+    params: { slug: keywordSlug(keyword) },
+    props: { keyword, buckets: [[keyword, papers]] as KeywordEntries },
+  }));
+}
+
+export async function GET(context: APIContext) {
+  const { keyword, buckets } = context.props as { keyword: string; buckets: KeywordEntries };
+  return feedResponse(context, {
+    title: `NLP Arxiv Daily — ${keyword}`,
+    description: `Daily-refreshed arxiv papers matching "${keyword}"`,
+    items: buildFeedItems(buckets),
+  });
+}

--- a/web/src/utils/feed.ts
+++ b/web/src/utils/feed.ts
@@ -1,0 +1,46 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { parsePaperRow } from "./paperRow.ts";
+import type { KeywordEntries } from "./papers.ts";
+
+export interface FeedItem {
+  title: string;
+  link: string;
+  pubDate: Date;
+  description: string;
+  customData: string;
+}
+
+/**
+ * Flatten keyword buckets into RSS items, newest first. A paper matched by
+ * several keywords appears once per keyword in the main feed — readers
+ * de-duplicate on <link>, and the <category> tells them which keyword hit.
+ */
+export function buildFeedItems(buckets: KeywordEntries): FeedItem[] {
+  const items: FeedItem[] = [];
+  for (const [keyword, papers] of buckets) {
+    for (const [paperId, row] of Object.entries(papers)) {
+      const parsed = parsePaperRow(row);
+      if (!parsed) continue;
+      items.push({
+        title: parsed.title,
+        link: parsed.paperUrl,
+        pubDate: new Date(parsed.date),
+        description: `${parsed.firstAuthor} et al. — arxiv:${paperId} — ${keyword}`,
+        customData: `<category>${keyword}</category>`,
+      });
+    }
+  }
+  items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+  return items;
+}
+
+export function feedResponse(
+  context: APIContext,
+  opts: { title: string; description: string; items: FeedItem[] },
+) {
+  // The channel <link> should point at the actual home page, which lives
+  // under the base path (/nlp-arxiv-daily/) — Astro.site by itself drops it.
+  const homeUrl = new URL(import.meta.env.BASE_URL, context.site!).toString();
+  return rss({ title: opts.title, description: opts.description, site: homeUrl, items: opts.items });
+}


### PR DESCRIPTION
## Summary
- Add a static RSS endpoint per keyword: `/rss/<keyword-slug>.xml` (e.g. `/rss/rag.xml`, `/rss/llm-agent.xml`), generated from the same keyword list as the Latest page.
- Add an `rss` link to each keyword section header on the Latest page, next to the `.bib` link. Archive months don't get one since they never update.
- Extract the item builder into `utils/feed.ts`; `/rss.xml` keeps the same item shape and `<category>` tags, and now reads via `resolveLatest()` so it matches the page during the early-month fallback.

## Test plan
- [x] `NODE_ENV=production astro build` passes; 23 feeds under `dist/rss/`, one per non-empty keyword
- [x] `/rss/rag.xml` contains only RAG items (34) with the keyword in the channel title; `/rss.xml` still contains all 623 items
- [x] Section headers link to `/nlp-arxiv-daily/rss/<slug>.xml`
- [ ] Subscribe to one keyword feed in a reader after deploy and confirm it validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)