### PR TITLE
feat: structured paper records with full authors, abstract, categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ arXiv API ──► fetcher ──► JSON snapshots ──► Astro static site
 
 A GitHub Actions cron runs every 12 hours: it queries arXiv per keyword, merges results into the monthly JSON archives, then triggers an Astro rebuild and deploy.
 
+Each JSON file is `{keyword: {arxiv_id: paper}}`, where `paper` is a record like:
+
+```json
+{
+  "date": "2026-09-07",
+  "title": "…",
+  "authors": ["Ada Lovelace", "Alan Turing"],
+  "url": "http://arxiv.org/abs/2609.05339v1",
+  "code": "https://github.com/x/y",
+  "abstract": "…",
+  "categories": ["cs.CL", "cs.IR"]
+}
+```
+
+Papers fetched before September 2026 are stored as a one-line markdown string instead (title, first author, date, links only); the site renders both. The JSON files are stable and safe to consume directly if you want the data without the website.
+
 Code lives in `nlp_arxiv_daily/` (Python pipeline) and `web/` (Astro site).
 
 ## 🍴 Fork & make it yours

--- a/nlp_arxiv_daily/core.py
+++ b/nlp_arxiv_daily/core.py
@@ -5,30 +5,32 @@ import logging
 import yaml
 
 from nlp_arxiv_daily.fetcher import fetch_papers
-from nlp_arxiv_daily.types import Paper
+from nlp_arxiv_daily.records import paper_to_web_record
+from nlp_arxiv_daily.types import Paper, PaperValue
 
 
 logging.basicConfig(format="[%(asctime)s %(levelname)s] %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.INFO)
 
 
 def papers_to_legacy_rows(papers: list[Paper], topic: str) -> tuple[dict, dict]:
-    """Render a list[Paper] into ({topic: {paper_id: row}}, {topic: {paper_id: web_row}}).
+    """Render a list[Paper] into ({topic: {paper_id: row}}, {topic: {paper_id: record}}).
+
+    The README flavor keeps its pipe-table markdown row. The gitpage (web)
+    flavor is a structured `WebRecord` dict — the Astro site parses both this
+    and the older one-line string rows still present in the archive JSONs.
 
     Shared by `get_daily_papers` (daily cron) and `cli.cmd_backfill` so both
-    persist data in the same JSON shape the renderer expects.
+    persist data in the same JSON shape.
     """
     content: dict[str, str] = {}
-    content_to_web: dict[str, str] = {}
+    content_to_web: dict[str, PaperValue] = {}
     for p in papers:
         code_md = f"**[link]({p.code_link})**" if p.code_link else "null"
         content[p.paper_id] = (
             f"|**{p.update_time}**|**{p.title}**|{p.first_author} et.al."
             f"|[{p.arxiv_short_id}]({p.paper_url})|{code_md}|\n"
         )
-        web_line = f"- {p.update_time}, **{p.title}**, {p.first_author} et.al., Paper: [{p.paper_url}]({p.paper_url})"
-        if p.code_link:
-            web_line += f", Code: **[{p.code_link}]({p.code_link})**"
-        content_to_web[p.paper_id] = web_line + "\n"
+        content_to_web[p.paper_id] = paper_to_web_record(p)
 
     return {topic: content}, {topic: content_to_web}
 

--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -149,8 +149,13 @@ def _result_to_paper(result) -> Paper:
     """
     short_id = result.get_short_id()
     paper_id = _strip_version_suffix(short_id)
+    authors = tuple(str(a) for a in result.authors)
     first_author = get_authors(result.authors, first_author=True)
     update_time = result.published.date()
+    # arxiv summaries are hard-wrapped at ~80 cols; collapse to one line.
+    abstract = " ".join((result.summary or "").split())
+    # Fakes in tests (and very old arxiv library versions) may lack this.
+    categories = tuple(getattr(result, "categories", None) or ())
 
     logging.info(f"Time = {update_time} title = {result.title} author = {first_author}")
 
@@ -162,6 +167,9 @@ def _result_to_paper(result) -> Paper:
         paper_url=result.entry_id,
         code_link=find_code_link(paper_id, summary=result.summary),
         arxiv_short_id=short_id,
+        authors=authors,
+        abstract=abstract,
+        categories=categories,
     )
 
 

--- a/nlp_arxiv_daily/records.py
+++ b/nlp_arxiv_daily/records.py
@@ -1,0 +1,42 @@
+"""Conversions between `Paper`, the structured `WebRecord` persisted in the
+gitpage JSON files, and the legacy one-line markdown row.
+
+The JSON files under docs/ are append-only across years, so both shapes
+coexist indefinitely: rows written before the switch stay strings, anything
+the pipeline fetches afterwards is a dict. `web_record_to_line` lets the
+(retired, but still tested) markdown renderer treat both uniformly.
+"""
+
+from __future__ import annotations
+
+from nlp_arxiv_daily.types import Paper, PaperValue, WebRecord
+
+
+def paper_to_web_record(p: Paper) -> WebRecord:
+    authors = list(p.authors) if p.authors else [p.first_author]
+    return {
+        "date": p.update_time.isoformat(),
+        "title": p.title,
+        "authors": authors,
+        "url": p.paper_url,
+        "code": p.code_link,
+        "abstract": p.abstract,
+        "categories": list(p.categories),
+    }
+
+
+def web_line(date: str, title: str, first_author: str, url: str, code: str | None) -> str:
+    """The legacy gitpage row: `- <date>, **<title>**, <author> et.al., Paper: [url](url)[, Code: **[c](c)**]`."""
+    line = f"- {date}, **{title}**, {first_author} et.al., Paper: [{url}]({url})"
+    if code:
+        line += f", Code: **[{code}]({code})**"
+    return line + "\n"
+
+
+def web_record_to_line(value: PaperValue) -> str:
+    """Legacy string rows pass through untouched; dict records are rendered
+    into the identical line shape."""
+    if isinstance(value, str):
+        return value
+    authors = value.get("authors") or [""]
+    return web_line(value["date"], value["title"], authors[0], value["url"], value.get("code"))

--- a/nlp_arxiv_daily/renderer.py
+++ b/nlp_arxiv_daily/renderer.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 
+from nlp_arxiv_daily.records import web_record_to_line
 from nlp_arxiv_daily.types import PapersByKeyword
 
 
@@ -115,7 +116,7 @@ def _keyword_section(
         lines.append("|Publish Date|Title|Authors|PDF|Code|\n|---|---|---|---|---|\n")
     for _, v in sort_papers(day_content).items():
         if v is not None:
-            lines.append(pretty_math(v))
+            lines.append(pretty_math(web_record_to_line(v)))
     lines.append("\n")
     lines.append(_back_to_top_line(date_now))
     return "".join(lines)

--- a/nlp_arxiv_daily/types.py
+++ b/nlp_arxiv_daily/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 @dataclass(frozen=True)
@@ -14,11 +14,32 @@ class Paper:
     paper_url: str
     code_link: str | None
     arxiv_short_id: str = ""  # raw arxiv short id incl. version, e.g. "2108.09112v1"
+    # Structured extras captured since the web JSON moved to dict records.
+    # Tuples (not lists) so the frozen dataclass stays hashable.
+    authors: tuple[str, ...] = ()
+    abstract: str = ""
+    categories: tuple[str, ...] = ()  # arxiv categories, primary first
 
 
 class KeywordConfig(TypedDict):
     filters: list[str]
 
 
-PapersByKeyword = dict[str, dict[str, str]]
-PapersByMonth = dict[str, dict[str, dict[str, str]]]
+class WebRecord(TypedDict):
+    """One paper in the gitpage JSON files (docs/*.json). Replaces the
+    one-line markdown string; old files still hold strings, so consumers
+    must accept `str | WebRecord`."""
+
+    date: str  # ISO YYYY-MM-DD submission date
+    title: str
+    authors: list[str]
+    url: str  # arxiv abs URL incl. version
+    code: str | None
+    abstract: str
+    categories: list[str]
+
+
+# Value is a legacy markdown row (str) or a WebRecord (dict).
+PaperValue = str | dict[str, Any]
+PapersByKeyword = dict[str, dict[str, PaperValue]]
+PapersByMonth = dict[str, dict[str, dict[str, PaperValue]]]

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -295,9 +295,11 @@ class TestGetDailyPapersAdapter:
         assert "[2604.21637v2](http://arxiv.org/abs/2604.21637v2)" in row
         assert "|null|" in row  # no code link
 
-        web_row = data_web["NLP"]["2604.21637"]
-        assert web_row.startswith("- 2026-04-22, **T**, Alice et.al.")
-        assert "Code:" not in web_row  # no code link
+        web_rec = data_web["NLP"]["2604.21637"]
+        assert web_rec["date"] == "2026-04-22"
+        assert web_rec["title"] == "T"
+        assert web_rec["authors"] == ["Alice"]
+        assert web_rec["code"] is None  # no code link
 
     def test_renders_code_link_when_present(self, monkeypatch):
         from nlp_arxiv_daily import get_daily_papers
@@ -311,8 +313,8 @@ class TestGetDailyPapersAdapter:
         data, data_web = get_daily_papers("NLP", query="x", max_results=1)
         row = data["NLP"]["2604.00001"]
         assert "**[link](https://github.com/x/y)**" in row
-        web_row = data_web["NLP"]["2604.00001"]
-        assert "Code: **[https://github.com/x/y](https://github.com/x/y)**" in web_row
+        web_rec = data_web["NLP"]["2604.00001"]
+        assert web_rec["code"] == "https://github.com/x/y"
 
 
 class _FlakyFakeClient:
@@ -554,3 +556,54 @@ class TestFindCodeLinkRetry:
         # Persistent 429: graceful degradation — return None, don't raise.
         assert fetcher.find_code_link("2604.00003") is None
         assert calls["n"] >= 2  # actually retried, not a single failure
+
+
+class TestResultToPaperStructuredFields:
+    def test_captures_authors_abstract_categories(self):
+        from nlp_arxiv_daily.fetcher import _result_to_paper
+
+        r = _FakeArxivResult(
+            short_id="2604.21637v1",
+            authors=["Alice", "Bob"],
+            summary="  Line one\nline two.  ",
+        )
+        r.categories = ["cs.CL", "cs.AI"]
+        p = _result_to_paper(r)
+        assert p.authors == ("Alice", "Bob")
+        assert p.abstract == "Line one line two."
+        assert p.categories == ("cs.CL", "cs.AI")
+
+    def test_missing_categories_is_empty(self):
+        from nlp_arxiv_daily.fetcher import _result_to_paper
+
+        p = _result_to_paper(_FakeArxivResult(short_id="2604.21637v1"))
+        assert p.categories == ()
+
+
+class TestGetDailyPapersWebRecords:
+    def test_web_flavor_is_structured_record(self, monkeypatch):
+        from nlp_arxiv_daily import get_daily_papers
+
+        _silence_code_link(monkeypatch)
+        _patch_arxiv(
+            monkeypatch,
+            [
+                _FakeArxivResult(
+                    short_id="2604.21637v2",
+                    title="T",
+                    authors=["Alice", "Bob"],
+                    updated=datetime.datetime(2026, 4, 22),
+                    entry_id="http://arxiv.org/abs/2604.21637v2",
+                    summary="An abstract.",
+                )
+            ],
+        )
+        _, data_web = get_daily_papers("NLP", query="x", max_results=1)
+        rec = data_web["NLP"]["2604.21637"]
+        assert isinstance(rec, dict)
+        assert rec["title"] == "T"
+        assert rec["authors"] == ["Alice", "Bob"]
+        assert rec["abstract"] == "An abstract."
+        assert rec["date"] == "2026-04-22"
+        assert rec["url"] == "http://arxiv.org/abs/2604.21637v2"
+        assert rec["code"] is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,7 +47,7 @@ def test_get_daily_papers_end_to_end():
         assert "et.al." in line
         assert "|**[link](" in line or "|null|" in line
 
-    for line in web_papers.values():
-        assert line.startswith("- ")
-        assert "et.al." in line
-        assert "Paper: [" in line
+    for rec in web_papers.values():
+        assert isinstance(rec, dict)
+        assert rec["title"] and rec["authors"] and rec["url"].startswith("http")
+        assert rec["date"] and rec["abstract"]

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,80 @@
+"""Structured web records: {date, title, authors, url, code, abstract, categories}
+replace the one-line markdown strings in the gitpage JSON files going forward.
+Old string rows stay valid — the Astro site and the renderer accept both."""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+from nlp_arxiv_daily.records import paper_to_web_record, web_record_to_line
+from nlp_arxiv_daily.types import Paper
+
+
+def _paper(**overrides) -> Paper:
+    base = {
+        "paper_id": "2604.21637",
+        "title": "A Title",
+        "first_author": "Alice",
+        "update_time": datetime.date(2026, 4, 22),
+        "paper_url": "http://arxiv.org/abs/2604.21637v1",
+        "code_link": None,
+        "arxiv_short_id": "2604.21637v1",
+        "authors": ("Alice", "Bob"),
+        "abstract": "We study things.",
+        "categories": ("cs.CL", "cs.AI"),
+    }
+    return Paper(**{**base, **overrides})
+
+
+class TestPaperDefaults:
+    def test_new_fields_default_empty(self):
+        p = Paper(
+            paper_id="2604.21637",
+            title="T",
+            first_author="Alice",
+            update_time=datetime.date(2026, 4, 22),
+            paper_url="u",
+            code_link=None,
+        )
+        assert p.authors == ()
+        assert p.abstract == ""
+        assert p.categories == ()
+
+
+class TestPaperToWebRecord:
+    def test_record_shape(self):
+        rec = paper_to_web_record(_paper(code_link="https://github.com/x/y"))
+        assert rec == {
+            "date": "2026-04-22",
+            "title": "A Title",
+            "authors": ["Alice", "Bob"],
+            "url": "http://arxiv.org/abs/2604.21637v1",
+            "code": "https://github.com/x/y",
+            "abstract": "We study things.",
+            "categories": ["cs.CL", "cs.AI"],
+        }
+
+    def test_record_is_json_serialisable(self):
+        json.dumps(paper_to_web_record(_paper()))
+
+    def test_no_authors_falls_back_to_first_author(self):
+        rec = paper_to_web_record(_paper(authors=()))
+        assert rec["authors"] == ["Alice"]
+
+
+class TestWebRecordToLine:
+    LEGACY = (
+        "- 2026-04-22, **A Title**, Alice et.al., "
+        "Paper: [http://arxiv.org/abs/2604.21637v1](http://arxiv.org/abs/2604.21637v1)\n"
+    )
+
+    def test_string_passthrough(self):
+        assert web_record_to_line(self.LEGACY) is self.LEGACY
+
+    def test_record_renders_legacy_line(self):
+        assert web_record_to_line(paper_to_web_record(_paper())) == self.LEGACY
+
+    def test_record_with_code_link(self):
+        line = web_record_to_line(paper_to_web_record(_paper(code_link="https://github.com/x/y")))
+        assert line.endswith(", Code: **[https://github.com/x/y](https://github.com/x/y)**\n")

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -9,6 +9,7 @@ Two layers:
 """
 
 import datetime
+import json
 import shutil
 from pathlib import Path
 
@@ -244,3 +245,35 @@ class TestKeywordSection:
 def _cleanup_logging_basic_config():
     """The renderer logs a 'finished' message; nothing to clean up — placeholder."""
     yield
+
+
+class TestWebRecordsRender:
+    def test_structured_record_renders_same_as_legacy_line(self, tmp_path):
+        """Mixed JSON (old string rows + new dict records) must render the
+        same markdown as an all-string file — the retired docs/index.md path
+        and its golden tests keep working during the format transition."""
+        legacy = (
+            "- 2026-04-21, **First Paper**, Alice et.al., "
+            "Paper: [http://arxiv.org/abs/2604.00001v1](http://arxiv.org/abs/2604.00001v1)\n"
+        )
+        record = {
+            "date": "2026-04-22",
+            "title": "Second Paper",
+            "authors": ["Bob", "Carol"],
+            "url": "http://arxiv.org/abs/2604.00002v1",
+            "code": "https://github.com/foo/bar",
+            "abstract": "Long abstract.",
+            "categories": ["cs.CL"],
+        }
+        mixed = tmp_path / "mixed.json"
+        mixed.write_text(json.dumps({"NLP": {"2604.00001": legacy, "2604.00002": record}}))
+        out = tmp_path / "out.md"
+        render_index(str(mixed), str(out), to_web=True, show_badge=False, today=TODAY)
+        text = out.read_text()
+        assert legacy in text
+        assert (
+            "- 2026-04-22, **Second Paper**, Bob et.al., "
+            "Paper: [http://arxiv.org/abs/2604.00002v1](http://arxiv.org/abs/2604.00002v1), "
+            "Code: **[https://github.com/foo/bar](https://github.com/foo/bar)**\n"
+        ) in text
+        assert "Long abstract." not in text

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -206,3 +206,34 @@ class TestWritePapersSplitRoundTrip:
         )
         main = json.loads(open(paths["main"]).read())
         assert list(main.keys()) == ["NLP", "Surprise"]
+
+
+class TestWebRecordsStorage:
+    def test_dict_values_round_trip_and_override_strings(self, tmp_path):
+        """A re-fetched paper arrives as a dict and must replace its old
+        string row for the same id; untouched string rows survive as-is."""
+        main = tmp_path / "main.json"
+        archive = tmp_path / "archive"
+        main.write_text(
+            json.dumps(
+                {
+                    "NLP": {
+                        "2604.00001": "- 2026-04-21, **Old**, A et.al., Paper: [u](u)\n",
+                        "2604.00002": "- 2026-04-22, **Keep**, B et.al., Paper: [u](u)\n",
+                    }
+                }
+            )
+        )
+        record = {
+            "date": "2026-04-21",
+            "title": "Old",
+            "authors": ["A", "Z"],
+            "url": "u",
+            "code": None,
+            "abstract": "abs",
+            "categories": [],
+        }
+        write_papers_split([{"NLP": {"2604.00001": record}}], str(main), str(archive), current_yymm="2604")
+        out = json.loads(main.read_text())
+        assert out["NLP"]["2604.00001"] == record
+        assert out["NLP"]["2604.00002"].startswith("- 2026-04-22, **Keep**")

--- a/web/src/components/KeywordSection.astro
+++ b/web/src/components/KeywordSection.astro
@@ -1,12 +1,12 @@
 ---
 import PaperCard from "./PaperCard.astro";
-import { sortPapersDesc } from "../utils/paperRow.ts";
+import { sortPapersDesc, type PaperValue } from "../utils/paperRow.ts";
 import { keywordSlug } from "../utils/keyword.ts";
 import { withBase } from "../utils/url.ts";
 
 interface Props {
   keyword: string;
-  papers: Record<string, string>;
+  papers: Record<string, PaperValue>;
   /** Directory holding this dataset's `.bib` files, e.g. "/bibtex" for the
    * Latest page or "/archive/2026-08" for a month. Omit to hide the link. */
   bibDir?: string;

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -1,19 +1,33 @@
 ---
-import { parsePaperRow } from "../utils/paperRow.ts";
+import { parsePaper, type PaperValue } from "../utils/paperRow.ts";
 import { paperBibtex } from "../utils/bibtex.ts";
 import { coinsTitle } from "../utils/coins.ts";
 
 interface Props {
   paperId: string;
-  row: string;
+  row: PaperValue;
   /** Keyword section the card sits in — becomes a Zotero tag via COinS. */
   keyword?: string;
 }
 
+const MAX_AUTHORS_SHOWN = 3;
+
 const { paperId, row, keyword } = Astro.props;
-const parsed = parsePaperRow(row);
+const parsed = parsePaper(row);
 const bibtex = parsed ? paperBibtex(paperId, parsed) : null;
 const coins = parsed ? coinsTitle(paperId, parsed, keyword) : null;
+
+// Legacy rows only know the first author → "X et al.". Records list up to
+// three names and append "et al." only when there are more.
+let byline = "";
+if (parsed) {
+  if (parsed.authors.length === 0) byline = `${parsed.firstAuthor} et al.`;
+  else {
+    const shown = parsed.authors.slice(0, MAX_AUTHORS_SHOWN).join(", ");
+    byline = parsed.authors.length > MAX_AUTHORS_SHOWN ? `${shown}, et al.` : shown;
+  }
+}
+const primaryCategory = parsed?.categories[0] ?? null;
 ---
 
 {parsed ? (
@@ -36,8 +50,13 @@ const coins = parsed ? coinsTitle(paperId, parsed, keyword) : null;
         {parsed.date}
       </time>
     </div>
-    <div class="flex items-center gap-3 text-sm text-(--color-muted)">
-      <span data-pagefind-meta="author">{parsed.firstAuthor} et al.</span>
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-(--color-muted)">
+      <span data-pagefind-meta="author">{byline}</span>
+      {primaryCategory && (
+        <span class="text-xs px-1.5 py-0.5 rounded border border-(--color-border)" title="arXiv primary category" data-pagefind-ignore>
+          {primaryCategory}
+        </span>
+      )}
       <a
         class="text-(--color-accent) hover:underline"
         href={parsed.paperUrl}
@@ -69,6 +88,14 @@ const coins = parsed ? coinsTitle(paperId, parsed, keyword) : null;
         bibtex
       </button>
     </div>
+    {parsed.abstract && (
+      <details class="mt-1 text-sm">
+        <summary class="cursor-pointer text-(--color-muted) hover:text-(--color-accent) select-none">
+          Abstract
+        </summary>
+        <p class="mt-1 leading-relaxed text-(--color-fg)/90">{parsed.abstract}</p>
+      </details>
+    )}
     {/* COinS: lets the Zotero connector save every paper on the page.
         Zero-size span by design — Zotero reads the title attribute only. */}
     <span class="Z3988" title={coins} aria-hidden="true" data-pagefind-ignore></span>

--- a/web/src/components/TableOfContents.astro
+++ b/web/src/components/TableOfContents.astro
@@ -1,8 +1,9 @@
 ---
 import { keywordSlug } from "../utils/keyword.ts";
+import type { KeywordEntries } from "../utils/papers.ts";
 
 interface Props {
-  keywords: Array<[string, Record<string, string>]>;
+  keywords: KeywordEntries;
 }
 
 const { keywords } = Astro.props;

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -1,11 +1,24 @@
 import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 
-// Each archive JSON file (docs/archive-web/YYYY-MM.json) is shaped as
-// {keyword: {paper_id: row_string}}. `row_string` is a one-line markdown
-// snippet emitted by the Python pipeline; PRSL-72 parses it back into
-// structured fields. Here we just validate the shape.
-export const paperBucketSchema = z.record(z.string(), z.record(z.string(), z.string()));
+// Structured record the Python pipeline writes since the format switch
+// (nlp_arxiv_daily/records.py). Older rows in the same files are one-line
+// markdown strings; utils/paperRow.ts parses both.
+export const paperRecordSchema = z.object({
+  date: z.string(),
+  title: z.string(),
+  authors: z.array(z.string()),
+  url: z.string(),
+  code: z.string().nullable(),
+  abstract: z.string(),
+  categories: z.array(z.string()),
+});
+
+export const paperValueSchema = z.union([z.string(), paperRecordSchema]);
+
+// Each JSON file (docs/nlp-arxiv-daily-web.json, docs/archive-web/YYYY-MM.json)
+// is shaped {keyword: {paper_id: string | record}}.
+export const paperBucketSchema = z.record(z.string(), z.record(z.string(), paperValueSchema));
 
 const archive = defineCollection({
   loader: glob({

--- a/web/src/utils/bibtex.ts
+++ b/web/src/utils/bibtex.ts
@@ -1,12 +1,13 @@
-import { parsePaperRow, type ParsedPaper } from "./paperRow.ts";
+import { parsePaper, type ParsedPaper, type PaperValue } from "./paperRow.ts";
 
 /**
  * BibTeX export.
  *
- * The pipeline only stores the first author, so entries carry
- * `author = {First Author and others}` — BibTeX renders "and others" as
- * "et al.", which is the honest representation of what we know. arXiv's own
- * export (https://arxiv.org/bibtex/<id>) has the full list if a reader needs it.
+ * Dict records carry the full author list, abstract and arxiv categories,
+ * so those entries are complete. Legacy string rows only know the first
+ * author and become `author = {First Author and others}` — BibTeX renders
+ * "and others" as "et al.", which is the honest representation of what we
+ * have; arXiv's own export (https://arxiv.org/bibtex/<id>) has the rest.
  */
 
 export interface BibEntry {
@@ -54,21 +55,30 @@ export function escapeTitle(title: string): string {
   return title.replace(/(?<!\\)([&%#_^])/g, "\\$1");
 }
 
+/** Abstracts are prose, not LaTeX: escape braces and the usual specials. */
+export function escapeAbstract(text: string): string {
+  return text.replace(/[\\{}]/g, "\\$&").replace(/([&%#_])/g, "\\$1");
+}
+
 export function formatEntry(entry: BibEntry, key: string): string {
   const { paperId, paper, keywords } = entry;
   const year = paper.date.slice(0, 4);
   const month = MONTHS[Number(paper.date.slice(5, 7)) - 1];
+  const author =
+    paper.authors.length > 0 ? paper.authors.join(" and ") : `${paper.firstAuthor} and others`;
   const fields: Array<[string, string]> = [
     ["title", `{${escapeTitle(paper.title)}}`],
-    ["author", `{${paper.firstAuthor} and others}`],
+    ["author", `{${author}}`],
     ["year", `{${year}}`],
     ["month", month ?? ""],
     ["eprint", `{${paperId}}`],
     ["archivePrefix", "{arXiv}"],
+    ["primaryClass", paper.categories[0] ? `{${paper.categories[0]}}` : ""],
     ["url", `{${paper.paperUrl}}`],
   ];
   if (paper.codeLink) fields.push(["note", `{Code: \\url{${paper.codeLink}}}`]);
   if (keywords.length > 0) fields.push(["keywords", `{${keywords.join(", ")}}`]);
+  if (paper.abstract) fields.push(["abstract", `{${escapeAbstract(paper.abstract)}}`]);
 
   const width = Math.max(...fields.map(([k]) => k.length));
   const body = fields
@@ -83,7 +93,7 @@ export function formatEntry(entry: BibEntry, key: string): string {
  * keywords is emitted once, with all of them in its `keywords` field. Cite
  * keys are de-duplicated with a/b/c suffixes.
  */
-export function buildBib(buckets: Array<[string, Record<string, string>]>, header?: string): string {
+export function buildBib(buckets: Array<[string, Record<string, PaperValue>]>, header?: string): string {
   const byId = new Map<string, BibEntry>();
   for (const [keyword, papers] of buckets) {
     for (const [paperId, row] of Object.entries(papers)) {
@@ -92,7 +102,7 @@ export function buildBib(buckets: Array<[string, Record<string, string>]>, heade
         existing.keywords.push(keyword);
         continue;
       }
-      const paper = parsePaperRow(row);
+      const paper = parsePaper(row);
       if (!paper) continue;
       byId.set(paperId, { paperId, paper, keywords: [keyword] });
     }

--- a/web/src/utils/coins.ts
+++ b/web/src/utils/coins.ts
@@ -10,7 +10,8 @@ import type { ParsedPaper } from "./paperRow.ts";
  *
  * Field choices follow zotero/utilities openurl.js `parseContextObject`:
  *  - `mtx:dc` + `rft.type=preprint` → Zotero "Preprint" item
- *  - `rft.creator` → author, `rft.date` → date, `rft.source` → repository
+ *  - `rft.creator` (one per author) → authors, `rft.date` → date,
+ *    `rft.source` → repository
  *  - `rft_id=info:doi/…` → DOI (every arXiv paper has a DataCite DOI)
  *  - `rft_id=https://…` → URL, `rft.subject` → tag
  */
@@ -20,7 +21,9 @@ export function coinsTitle(paperId: string, paper: ParsedPaper, keyword?: string
     ["rft_val_fmt", "info:ofi/fmt:kev:mtx:dc"],
     ["rft.type", "preprint"],
     ["rft.title", paper.title],
-    ["rft.creator", paper.firstAuthor],
+    ...(paper.authors.length > 0 ? paper.authors : [paper.firstAuthor]).map(
+      (a): [string, string] => ["rft.creator", a],
+    ),
     ["rft.date", paper.date],
     ["rft.source", "arXiv"],
     ["rft_id", `info:doi/10.48550/arXiv.${paperId}`],

--- a/web/src/utils/feed.ts
+++ b/web/src/utils/feed.ts
@@ -1,6 +1,6 @@
 import rss from "@astrojs/rss";
 import type { APIContext } from "astro";
-import { parsePaperRow } from "./paperRow.ts";
+import { parsePaper } from "./paperRow.ts";
 import type { KeywordEntries } from "./papers.ts";
 
 export interface FeedItem {
@@ -20,13 +20,16 @@ export function buildFeedItems(buckets: KeywordEntries): FeedItem[] {
   const items: FeedItem[] = [];
   for (const [keyword, papers] of buckets) {
     for (const [paperId, row] of Object.entries(papers)) {
-      const parsed = parsePaperRow(row);
+      const parsed = parsePaper(row);
       if (!parsed) continue;
+      const byline = `${parsed.firstAuthor} et al. — arxiv:${paperId} — ${keyword}`;
       items.push({
         title: parsed.title,
         link: parsed.paperUrl,
         pubDate: new Date(parsed.date),
-        description: `${parsed.firstAuthor} et al. — arxiv:${paperId} — ${keyword}`,
+        // Readers show the description inline, so lead with the abstract
+        // when we have one.
+        description: parsed.abstract ? `${parsed.abstract}\n\n${byline}` : byline,
         customData: `<category>${keyword}</category>`,
       });
     }

--- a/web/src/utils/paperRow.ts
+++ b/web/src/utils/paperRow.ts
@@ -1,5 +1,11 @@
 /**
- * Parse a legacy markdown paper row into structured fields.
+ * Parse one paper value from the JSON files into structured fields.
+ *
+ * Since the format switch the pipeline writes dict records
+ * ({date, title, authors, url, code, abstract, categories}); everything
+ * fetched before that is a one-line markdown string. Both coexist in the
+ * same files forever (the archive is append-only), so `parsePaper` accepts
+ * either. The string grammar is documented below.
  *
  * The Python pipeline historically emitted TWO row formats and the
  * gitpage-flavor archive JSONs ended up with both mixed in: bullet rows
@@ -18,12 +24,45 @@
  * Either way the parser is the read-side counterpart to
  * `core.papers_to_legacy_rows`.
  */
+export interface PaperRecord {
+  date: string;
+  title: string;
+  authors: string[];
+  url: string;
+  code: string | null;
+  abstract: string;
+  categories: string[];
+}
+
+export type PaperValue = string | PaperRecord;
+
 export interface ParsedPaper {
   date: string; // ISO YYYY-MM-DD
   title: string;
   firstAuthor: string;
+  /** Full author list when known (dict records); empty for legacy rows. */
+  authors: string[];
   paperUrl: string;
   codeLink: string | null;
+  abstract: string | null;
+  /** arxiv categories, primary first; empty for legacy rows. */
+  categories: string[];
+}
+
+export function parsePaper(value: PaperValue): ParsedPaper | null {
+  if (typeof value === "string") return parsePaperRow(value);
+  if (!value.title || !value.date || !value.url) return null;
+  const authors = value.authors ?? [];
+  return {
+    date: value.date,
+    title: value.title,
+    firstAuthor: authors[0] ?? "",
+    authors,
+    paperUrl: value.url,
+    codeLink: value.code ?? null,
+    abstract: value.abstract ? value.abstract : null,
+    categories: value.categories ?? [],
+  };
 }
 
 const BULLET_RE =
@@ -38,7 +77,16 @@ export function parsePaperRow(row: string): ParsedPaper | null {
   const bullet = trimmed.match(BULLET_RE);
   if (bullet) {
     const [, date, title, firstAuthor, paperUrl, codeLink] = bullet;
-    return { date, title, firstAuthor, paperUrl, codeLink: codeLink ?? null };
+    return {
+      date,
+      title,
+      firstAuthor,
+      authors: [],
+      paperUrl,
+      codeLink: codeLink ?? null,
+      abstract: null,
+      categories: [],
+    };
   }
 
   const pipe = trimmed.match(PIPE_RE);
@@ -50,8 +98,11 @@ export function parsePaperRow(row: string): ParsedPaper | null {
       date,
       title,
       firstAuthor,
+      authors: [],
       paperUrl,
       codeLink: codeMatch ? codeMatch[1] : null,
+      abstract: null,
+      categories: [],
     };
   }
 
@@ -62,6 +113,6 @@ export function parsePaperRow(row: string): ParsedPaper | null {
  * Sort papers within a keyword section: newest paper id first (which mirrors
  * what the Python renderer does, since arxiv ids are monotonic by submission).
  */
-export function sortPapersDesc(papers: Record<string, string>): Array<[string, string]> {
+export function sortPapersDesc(papers: Record<string, PaperValue>): Array<[string, PaperValue]> {
   return Object.entries(papers).sort(([a], [b]) => (a < b ? 1 : a > b ? -1 : 0));
 }

--- a/web/src/utils/papers.ts
+++ b/web/src/utils/papers.ts
@@ -1,9 +1,10 @@
 import { getCollection } from "astro:content";
 import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../content.config.ts";
+import type { PaperValue } from "./paperRow.ts";
 
-export type PaperBucket = Record<string, Record<string, string>>;
-export type KeywordEntries = Array<[string, Record<string, string>]>;
+export type PaperBucket = Record<string, Record<string, PaperValue>>;
+export type KeywordEntries = Array<[string, Record<string, PaperValue>]>;
 
 export function nonEmptyKeywords(data: PaperBucket): KeywordEntries {
   return Object.entries(data).filter(([, papers]) => Object.keys(papers).length > 0);


### PR DESCRIPTION
## Summary
- The gitpage JSON files (`docs/nlp-arxiv-daily-web.json`, `docs/archive-web/*.json`) now store each paper as a dict `{date, title, authors, url, code, abstract, categories}` instead of a one-line markdown string. Existing string rows are left untouched (the archive is append-only) and every consumer accepts both shapes, so no data migration is needed. README documents the record format.
- **Python:** `Paper` gains `authors` / `abstract` / `categories` (tuples, default empty); the fetcher fills them from `arxiv.Result` and collapses the hard-wrapped abstract to one line. New `records.py` holds `paper_to_web_record` and `web_record_to_line`; the renderer normalises dict values so the retired `to_web` markdown path and its golden tests still pass on mixed files. README flavor rows are unchanged.
- **Web:** content schema accepts `string | record`, `parsePaper()` dispatches. Cards show up to three authors, the primary arxiv category, and a collapsible abstract (Pagefind indexes it, so search covers abstracts going forward). BibTeX entries get the full author list, `primaryClass` and `abstract`; legacy rows keep `and others`. COinS emits one `rft.creator` per author. RSS descriptions lead with the abstract when present.

Follow-up (not in this PR): abstracts only appear for papers fetched after this lands. Running `python -m nlp_arxiv_daily backfill --start 2026-09` once would upgrade the current month's existing entries.

## Test plan
- [x] `make test`: 151 passed, coverage 95% (new tests in `tests/test_records.py`, plus fetcher/renderer/storage cases for dict records and mixed files)
- [x] `make quality` clean
- [x] `NODE_ENV=production astro build` passes on the real data (all string rows) and on a copy with an injected record: card shows "A, B, C, et al." + `cs.CL` badge + Abstract `<details>`; `.bib` entry has full `author`, `primaryClass`, escaped `abstract`; COinS has four `rft.creator`; RSS description starts with the abstract
- [x] Storage round-trip: a dict record for an id replaces its old string row; other string rows survive
- [ ] After the next cron run: new papers on the Latest page show authors/abstract, older ones still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)