### PR TITLE
fix: drop abstract from per-card BibTeX attr, cap RSS item counts

### DIFF
--- a/web/src/pages/rss.xml.ts
+++ b/web/src/pages/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { buildFeedItems, feedResponse } from "../utils/feed.ts";
+import { MAIN_FEED_LIMIT, buildFeedItems, feedResponse } from "../utils/feed.ts";
 import { resolveLatest } from "../utils/papers.ts";
 
 /** /rss.xml — every keyword. Per-keyword feeds live at /rss/<slug>.xml. */
@@ -8,6 +8,6 @@ export async function GET(context: APIContext) {
   return feedResponse(context, {
     title: "NLP Arxiv Daily",
     description: "Daily-refreshed NLP arxiv paper digest",
-    items: buildFeedItems(keywords),
+    items: buildFeedItems(keywords, MAIN_FEED_LIMIT),
   });
 }

--- a/web/src/pages/rss/[slug].xml.ts
+++ b/web/src/pages/rss/[slug].xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { buildFeedItems, feedResponse } from "../../utils/feed.ts";
+import { KEYWORD_FEED_LIMIT, buildFeedItems, feedResponse } from "../../utils/feed.ts";
 import { keywordSlug } from "../../utils/keyword.ts";
 import { resolveLatest, type KeywordEntries } from "../../utils/papers.ts";
 
@@ -17,6 +17,6 @@ export async function GET(context: APIContext) {
   return feedResponse(context, {
     title: `NLP Arxiv Daily — ${keyword}`,
     description: `Daily-refreshed arxiv papers matching "${keyword}"`,
-    items: buildFeedItems(buckets),
+    items: buildFeedItems(buckets, KEYWORD_FEED_LIMIT),
   });
 }

--- a/web/src/utils/bibtex.ts
+++ b/web/src/utils/bibtex.ts
@@ -125,7 +125,12 @@ export function buildBib(buckets: Array<[string, Record<string, PaperValue>]>, h
   return preamble + blocks.join("\n\n") + "\n";
 }
 
-/** Single-paper BibTeX for the per-card copy button. */
+/**
+ * Single-paper BibTeX for the per-card copy button. Deliberately drops the
+ * abstract: the entry is inlined as a data attribute on every card, and
+ * ~1.2 KB of abstract × 2000 cards was adding 2–3 MB to a list page. The
+ * downloadable .bib files keep the abstract.
+ */
 export function paperBibtex(paperId: string, paper: ParsedPaper): string {
-  return formatEntry({ paperId, paper, keywords: [] }, citeKey(paperId, paper));
+  return formatEntry({ paperId, paper: { ...paper, abstract: null }, keywords: [] }, citeKey(paperId, paper));
 }

--- a/web/src/utils/feed.ts
+++ b/web/src/utils/feed.ts
@@ -11,12 +11,19 @@ export interface FeedItem {
   customData: string;
 }
 
+/** Item caps: feeds are re-fetched by readers every hour or so, and each
+ * item now carries an abstract, so an uncapped month (2000+ items, ~3 MB)
+ * is unreasonable. Readers keep older items they already saw. */
+export const MAIN_FEED_LIMIT = 200;
+export const KEYWORD_FEED_LIMIT = 100;
+
 /**
- * Flatten keyword buckets into RSS items, newest first. A paper matched by
- * several keywords appears once per keyword in the main feed — readers
- * de-duplicate on <link>, and the <category> tells them which keyword hit.
+ * Flatten keyword buckets into RSS items, newest first, capped at `limit`.
+ * A paper matched by several keywords appears once per keyword in the main
+ * feed — readers de-duplicate on <link>, and the <category> tells them
+ * which keyword hit.
  */
-export function buildFeedItems(buckets: KeywordEntries): FeedItem[] {
+export function buildFeedItems(buckets: KeywordEntries, limit: number): FeedItem[] {
   const items: FeedItem[] = [];
   for (const [keyword, papers] of buckets) {
     for (const [paperId, row] of Object.entries(papers)) {
@@ -35,7 +42,7 @@ export function buildFeedItems(buckets: KeywordEntries): FeedItem[] {
     }
   }
   items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
-  return items;
+  return items.slice(0, limit);
 }
 
 export function feedResponse(


### PR DESCRIPTION
## Summary
- The per-card `bibtex` copy button inlined the full entry, abstract included, as a data attribute. With structured records that duplicated every abstract (once in the collapsible `<details>`, once in the attribute). Measured on the backfilled September data (1974 cards): `index.html` 10.4 MB → 7.7 MB raw. The downloadable `.bib` files still include abstracts.
- Cap RSS: main feed 200 items, per-keyword feeds 100 items. Uncapped, the main feed with abstracts was 3.4 MB; now 0.35 MB.

Not addressed here: a month page with ~2000 cards and abstracts is still ~7.7 MB raw / 1.6 MB gzipped. Pre-existing archive months are already 6+ MB. A real fix is pagination or per-keyword pages, which is a separate design decision.

## Test plan
- [x] `NODE_ENV=production astro build` against the `data/backfill-2026-09` JSON: 7.67 MB index, 200 / 100 / 44 items in `/rss.xml`, `/rss/llm.xml`, `/rss/rag.xml`; `all.bib` still has 1118 abstracts
- [x] Data file restored, only web sources in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)