### PR TITLE
feat: Latest page shows the last 7 days; current month gets an archive page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - 🔎 **Full-text search** across every paper (powered by [Pagefind](https://pagefind.app))
 - 🏷️ **Keyword tabs** — NLP, LLM, RAG, Reasoning, Multimodal, Long Context, Code LLM, …
-- 🗓️ **Monthly archives** going back to launch
+- 🗓️ **Latest = the last 7 days**, with **monthly archives** (including the current month) going back to launch
 - 📡 **[RSS feed](https://monologg.kr/nlp-arxiv-daily/rss.xml)** for your reader of choice — plus one feed per keyword (e.g. [`/rss/rag.xml`](https://monologg.kr/nlp-arxiv-daily/rss/rag.xml), `/rss/llm-agent.xml`)
 - 📥 **BibTeX export** — per paper (copy button), per keyword, or the whole page / month as one `.bib` file (e.g. [`/bibtex/all.bib`](https://monologg.kr/nlp-arxiv-daily/bibtex/all.bib), `/bibtex/rag.bib`, `/archive/2026-08/all.bib`)
 - 🗂️ **Zotero-ready** — every list page embeds [COinS](https://en.wikipedia.org/wiki/COinS) metadata, so the Zotero connector can save all papers on a page in one click (as Preprint items with DOI, URL, and the keyword as a tag)

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -32,7 +32,7 @@ const primaryCategory = parsed?.categories[0] ?? null;
 
 {parsed ? (
   <article
-    class="py-3 border-b border-(--color-border) last:border-b-0"
+    class="paper-card py-3 border-b border-(--color-border) last:border-b-0"
     data-pagefind-body
   >
     <div class="flex items-baseline justify-between gap-3 mb-1">

--- a/web/src/pages/archive/[month].astro
+++ b/web/src/pages/archive/[month].astro
@@ -3,21 +3,22 @@ import Layout from "../../layouts/Layout.astro";
 import KeywordSection from "../../components/KeywordSection.astro";
 import TableOfContents from "../../components/TableOfContents.astro";
 import { withBase } from "../../utils/url.ts";
-import { getCollection } from "astro:content";
+import { allMonths, nonEmptyKeywords, type MonthEntry } from "../../utils/papers.ts";
 
+// Archive snapshots plus the live current month (not in the archive dir
+// until the month rolls over, but it's where the Latest page's "browse all
+// of this month" link points).
 export async function getStaticPaths() {
-  const entries = await getCollection("archive");
-  return entries.map((entry) => ({
+  const months = await allMonths();
+  return months.map((entry) => ({
     params: { month: entry.id },
     props: { entry },
   }));
 }
 
-const { entry } = Astro.props;
+const { entry } = Astro.props as { entry: MonthEntry };
 const data = entry.data;
-const keywords = Object.entries(data).filter(
-  ([, papers]) => Object.keys(papers).length > 0,
-);
+const keywords = nonEmptyKeywords(data);
 const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
   0,
@@ -41,6 +42,7 @@ const bibDir = `/archive/${entry.id}`;
       <h1 class="text-4xl font-bold mb-2">{entry.id}</h1>
       <p class="text-(--color-muted) text-sm">
         {totalPapers} papers across {keywords.length} keywords.
+        {entry.current && " Current month — grows with every 12-hour update."}
       </p>
       {keywords.length > 0 && (
         <p class="text-(--color-muted) text-sm mt-1">

--- a/web/src/pages/archive/[month]/[slug].bib.ts
+++ b/web/src/pages/archive/[month]/[slug].bib.ts
@@ -1,15 +1,14 @@
 import type { APIRoute } from "astro";
-import { getCollection } from "astro:content";
 import { buildBib } from "../../../utils/bibtex.ts";
 import { keywordSlug } from "../../../utils/keyword.ts";
-import { nonEmptyKeywords, type KeywordEntries } from "../../../utils/papers.ts";
+import { allMonths, nonEmptyKeywords, type KeywordEntries } from "../../../utils/papers.ts";
 
 /**
  * /archive/<YYYY-MM>/<keyword-slug>.bib — one keyword section of a month.
  * /archive/<YYYY-MM>/all.bib          — the whole month, de-duplicated.
  */
 export async function getStaticPaths() {
-  const entries = await getCollection("archive");
+  const entries = await allMonths();
   return entries.flatMap((entry) => {
     const keywords = nonEmptyKeywords(entry.data);
     const paths = keywords.map(([keyword, papers]) => ({

--- a/web/src/pages/archive/index.astro
+++ b/web/src/pages/archive/index.astro
@@ -1,11 +1,12 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { withBase } from "../../utils/url.ts";
-import { getCollection } from "astro:content";
+import { allMonths } from "../../utils/papers.ts";
 
-const entries = await getCollection("archive");
-// Sort newest first.
-const months = entries.map((e) => e.id).sort().reverse();
+// Newest first; includes the live current month.
+const entries = await allMonths();
+const months = entries.map((e) => e.id);
+const currentId = entries.find((e) => e.current)?.id ?? null;
 
 // Group by year so the long list is browsable on a dense screen.
 const byYear = new Map<string, string[]>();
@@ -35,7 +36,7 @@ for (const month of months) {
                 class="inline-block px-3 py-1 rounded border border-(--color-muted)/30 hover:border-(--color-accent) hover:text-(--color-accent) text-sm"
                 href={withBase(`/archive/${month}/`)}
               >
-                {month}
+                {month}{month === currentId && <span class="text-(--color-muted)"> · current</span>}
               </a>
             </li>
           ))}

--- a/web/src/pages/bibtex/[slug].bib.ts
+++ b/web/src/pages/bibtex/[slug].bib.ts
@@ -1,15 +1,17 @@
 import type { APIRoute } from "astro";
 import { buildBib } from "../../utils/bibtex.ts";
 import { keywordSlug } from "../../utils/keyword.ts";
-import { resolveLatest, type KeywordEntries } from "../../utils/papers.ts";
+import { resolveRecent, type KeywordEntries } from "../../utils/papers.ts";
 
 /**
- * /bibtex/<keyword-slug>.bib — every paper in one "Latest" keyword section.
+ * /bibtex/<keyword-slug>.bib — one keyword section of the Latest page.
  * /bibtex/all.bib          — the whole Latest page, de-duplicated.
+ * Both cover the same day window the page shows; whole months live at
+ * /archive/<YYYY-MM>/<slug>.bib.
  */
 export async function getStaticPaths() {
-  const { keywords, fallbackMonth } = await resolveLatest();
-  const label = fallbackMonth ?? "latest";
+  const { keywords, windowDays, since, monthId, widened } = await resolveRecent();
+  const label = widened ? `all of ${monthId}` : `last ${windowDays} days, since ${since}`;
   const paths = keywords.map(([keyword, papers]) => ({
     params: { slug: keywordSlug(keyword) },
     props: { buckets: [[keyword, papers]] as KeywordEntries, header: `NLP Arxiv Daily — ${keyword} (${label})` },

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,9 +4,9 @@ import KeywordFilter from "../components/KeywordFilter.astro";
 import KeywordSection from "../components/KeywordSection.astro";
 import TableOfContents from "../components/TableOfContents.astro";
 import { withBase } from "../utils/url.ts";
-import { resolveLatest } from "../utils/papers.ts";
+import { resolveRecent } from "../utils/papers.ts";
 
-const { keywords, fallbackMonth } = await resolveLatest();
+const { keywords, windowDays, since, monthId, widened } = await resolveRecent();
 
 const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
@@ -14,30 +14,38 @@ const totalPapers = keywords.reduce(
 );
 const today = new Date().toISOString().slice(0, 10);
 const bibDir = "/bibtex";
+const monthHref = monthId ? withBase(`/archive/${monthId}/`) : null;
 ---
 
 <Layout title="NLP Arxiv Daily" current="home">
-  <main class="max-w-3xl mx-auto px-6 py-10">
+  {/* Pagefind indexes the month pages instead — the same papers would
+      otherwise show up twice in search results while they're recent. */}
+  <main class="max-w-3xl mx-auto px-6 py-10" data-pagefind-ignore="all">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Updated {today}</h1>
-      {fallbackMonth ? (
+      {widened ? (
         <p class="text-(--color-muted) text-sm">
-          No papers yet this month — showing the latest snapshot from
-          {" "}
-          <a class="hover:text-(--color-accent) hover:underline" href={withBase(`/archive/${fallbackMonth}/`)}>
-            {fallbackMonth}
-          </a>
-          {" "}({totalPapers} papers across {keywords.length} keywords).
+          Nothing submitted in the last {windowDays} days yet — showing all of
+          {" "}{monthId} ({totalPapers} papers across {keywords.length} keywords).
         </p>
       ) : (
         <p class="text-(--color-muted) text-sm">
-          {totalPapers} papers across {keywords.length} keywords this month.
+          {totalPapers} papers across {keywords.length} keywords in the last {windowDays} days
+          (since {since}).
+          {monthHref && (
+            <>
+              {" "}
+              <a class="text-(--color-accent) hover:underline" href={monthHref}>
+                Browse all of {monthId} →
+              </a>
+            </>
+          )}
         </p>
       )}
       {keywords.length > 0 && (
         <p class="text-(--color-muted) text-sm mt-1">
           <a class="text-(--color-accent) hover:underline" href={withBase(`${bibDir}/all.bib`)} download>
-            Download all as BibTeX
+            Download this list as BibTeX
           </a>
           {" "}· <a class="text-(--color-accent) hover:underline" href={withBase("/rss.xml")}>RSS</a> (each keyword has its own feed, see section headers)
           {" "}· every paper on this page is also visible to the Zotero connector.

--- a/web/src/pages/og/[...slug].png.ts
+++ b/web/src/pages/og/[...slug].png.ts
@@ -1,7 +1,7 @@
 import { OGImageRoute } from "astro-og-canvas";
-import { getCollection } from "astro:content";
 import currentPapers from "../../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../../content.config.ts";
+import { allMonths } from "../../utils/papers.ts";
 
 interface OgPage {
   title: string;
@@ -21,11 +21,9 @@ const pages: Record<string, OgPage> = {
   },
 };
 
-// Add per-month archive cards.
-const archiveEntries = await getCollection("archive");
-for (const entry of archiveEntries) {
-  const data = paperBucketSchema.parse(entry.data);
-  const total = Object.values(data).reduce(
+// Add per-month archive cards (archive snapshots + the live current month).
+for (const entry of await allMonths()) {
+  const total = Object.values(entry.data).reduce(
     (sum, papers) => sum + Object.keys(papers).length,
     0,
   );

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -45,3 +45,11 @@ html.dark {
 body {
   transition: background-color 150ms ease, color 150ms ease;
 }
+
+/* Long lists (a whole month is 2000+ cards): let the browser skip layout
+   and paint for cards outside the viewport. The intrinsic size is a rough
+   collapsed-card height so the scrollbar stays stable. */
+.paper-card {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 5rem;
+}

--- a/web/src/utils/papers.ts
+++ b/web/src/utils/papers.ts
@@ -1,13 +1,65 @@
 import { getCollection } from "astro:content";
 import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../content.config.ts";
-import type { PaperValue } from "./paperRow.ts";
+import { parsePaper, type PaperValue } from "./paperRow.ts";
 
 export type PaperBucket = Record<string, Record<string, PaperValue>>;
 export type KeywordEntries = Array<[string, Record<string, PaperValue>]>;
 
+/** Days of papers the Latest page shows. Forks can override at build time
+ * with PUBLIC_LATEST_WINDOW_DAYS; the full month lives under /archive/. */
+export const LATEST_WINDOW_DAYS = Math.max(1, Number(import.meta.env.PUBLIC_LATEST_WINDOW_DAYS ?? 7) || 7);
+
 export function nonEmptyKeywords(data: PaperBucket): KeywordEntries {
   return Object.entries(data).filter(([, papers]) => Object.keys(papers).length > 0);
+}
+
+function totalRows(data: PaperBucket): number {
+  return Object.values(data).reduce((sum, papers) => sum + Object.keys(papers).length, 0);
+}
+
+/**
+ * "YYYY-MM" for the current-month JSON, derived from its arxiv ids (the
+ * pipeline buckets that file by id prefix, so the newest prefix is the
+ * month). Null when the file is empty.
+ */
+export function currentMonthId(data: PaperBucket): string | null {
+  let best: string | null = null;
+  for (const papers of Object.values(data)) {
+    for (const id of Object.keys(papers)) {
+      const m = id.match(/^(\d{2})(\d{2})\./);
+      if (!m) continue;
+      const ym = `20${m[1]}-${m[2]}`;
+      if (best === null || ym > best) best = ym;
+    }
+  }
+  return best;
+}
+
+export interface MonthEntry {
+  id: string; // "YYYY-MM"
+  data: PaperBucket;
+  /** True for the live current-month file (rebuilt every 12h). */
+  current: boolean;
+}
+
+/**
+ * Every month we can render a page for: the archive snapshots plus the
+ * current-month JSON (which is not in the archive until the month rolls
+ * over). Newest first. Empty months are dropped.
+ */
+export async function allMonths(): Promise<MonthEntry[]> {
+  const entries = await getCollection("archive");
+  const months: MonthEntry[] = entries
+    .filter((e) => totalRows(e.data) > 0)
+    .map((e) => ({ id: e.id, data: e.data, current: false }));
+
+  const currentData = paperBucketSchema.parse(currentPapers);
+  const currentId = currentMonthId(currentData);
+  if (currentId && !months.some((m) => m.id === currentId)) {
+    months.push({ id: currentId, data: currentData, current: true });
+  }
+  return months.sort((a, b) => b.id.localeCompare(a.id));
 }
 
 export interface LatestSnapshot {
@@ -19,10 +71,10 @@ export interface LatestSnapshot {
 }
 
 /**
- * The "Latest" dataset: the current-month JSON, or — early in a month before
- * the cron has landed anything — the newest non-empty archive snapshot.
- * Shared by the index page and the BibTeX endpoints so both agree on what
- * "latest" means.
+ * The newest whole month: the current-month JSON, or — early in a month
+ * before the cron has landed anything — the newest non-empty archive
+ * snapshot. Used by the RSS feeds, which want more history than the
+ * Latest page's day window.
  */
 export async function resolveLatest(): Promise<LatestSnapshot> {
   const currentData = paperBucketSchema.parse(currentPapers);
@@ -30,16 +82,57 @@ export async function resolveLatest(): Promise<LatestSnapshot> {
   if (currentKeywords.length > 0) {
     return { data: currentData, keywords: currentKeywords, fallbackMonth: null };
   }
+  const months = await allMonths();
+  if (months.length === 0) return { data: currentData, keywords: [], fallbackMonth: null };
+  return { data: months[0].data, keywords: nonEmptyKeywords(months[0].data), fallbackMonth: months[0].id };
+}
 
-  const entries = await getCollection("archive");
-  const candidates = entries
-    .map((e) => ({ id: e.id, data: e.data, keywords: nonEmptyKeywords(e.data) }))
-    .filter((c) => c.keywords.length > 0)
-    .sort((a, b) => b.id.localeCompare(a.id));
+export interface RecentSnapshot {
+  keywords: KeywordEntries;
+  windowDays: number;
+  /** ISO date (inclusive) the window starts at. */
+  since: string;
+  /** Month page that holds the full list the window was cut from. */
+  monthId: string | null;
+  /** True when the window held nothing and the whole newest month is shown. */
+  widened: boolean;
+}
 
-  if (candidates.length === 0) {
-    return { data: currentData, keywords: [], fallbackMonth: null };
+/**
+ * The Latest page dataset: papers submitted in the last `days` days, across
+ * the newest two months (so the window survives a month boundary). Keyword
+ * order follows the current-month file, i.e. config.yaml. If the window is
+ * empty (arxiv holiday, cron outage) the newest month is shown whole.
+ */
+export async function resolveRecent(days: number = LATEST_WINDOW_DAYS): Promise<RecentSnapshot> {
+  const months = await allMonths();
+  if (months.length === 0) return { keywords: [], windowDays: days, since: "", monthId: null, widened: false };
+
+  const sinceDate = new Date();
+  sinceDate.setUTCDate(sinceDate.getUTCDate() - (days - 1));
+  const since = sinceDate.toISOString().slice(0, 10);
+
+  const merged: PaperBucket = {};
+  for (const month of months.slice(0, 2)) {
+    for (const [keyword, papers] of Object.entries(month.data)) {
+      const bucket = (merged[keyword] ??= {});
+      for (const [id, value] of Object.entries(papers)) {
+        if (id in bucket) continue;
+        const parsed = parsePaper(value);
+        if (parsed && parsed.date >= since) bucket[id] = value;
+      }
+    }
   }
-  const latest = candidates[0];
-  return { data: latest.data, keywords: latest.keywords, fallbackMonth: latest.id };
+
+  const keywords = nonEmptyKeywords(merged);
+  if (keywords.length > 0) {
+    return { keywords, windowDays: days, since, monthId: months[0].id, widened: false };
+  }
+  return {
+    keywords: nonEmptyKeywords(months[0].data),
+    windowDays: days,
+    since,
+    monthId: months[0].id,
+    widened: true,
+  };
 }


### PR DESCRIPTION
## Summary
- **Latest = last 7 days.** `resolveRecent()` filters the newest two months by submission date (`PUBLIC_LATEST_WINDOW_DAYS`, default 7), so the page no longer grows through the month. Header links to "Browse all of YYYY-MM". If the window is empty (holiday, cron outage) the newest month is shown whole.
- **Current month archive page.** `allMonths()` merges archive snapshots with the live current-month JSON, so `/archive/2026-09/`, its `.bib` files and OG card exist before the month rolls over. The archive index tags it "current".
- **Latest `.bib` files** (`/bibtex/*.bib`) now cover the same window as the page; whole months are at `/archive/<month>/*.bib`.
- Latest page is excluded from Pagefind so search results don't show recent papers twice (month pages index them).
- `.paper-card { content-visibility: auto }` so 2000-card month pages paint lazily.

## Numbers (today, 2026-09-08, on the backfilled September data)
| page | cards | raw | gzip |
|---|---|---|---|
| Latest before | 1974 | 7.7 MB | 1.6 MB |
| Latest now (since 2026-09-02) | 1299 | 5.1 MB | 1.06 MB |
| `/archive/2026-09/` | 1974 | 7.7 MB | — |

The window still covers 7 of the 8 backfilled days, so the drop looks modest today; by month end the Latest page stays ~1300 cards while the month page grows to ~4000. Two further levers if that is still too heavy: a 3-day default, or a de-duplicated view (757 unique papers behind those 1299 rows).

## Test plan
- [x] `NODE_ENV=production astro build` passes; oldest date on Latest is 2026-09-02; `/bibtex/all.bib` header says "last 7 days, since 2026-09-02" with 757 entries; `/archive/2026-09/all.bib` has 1133
- [x] `/archive/2026-09/index.html`, `/og/archive/2026-09.png`, archive index "· current" badge all present
- [x] Latest `<main>` carries `data-pagefind-ignore="all"`; `.paper-card` rule in the bundled CSS
- [ ] After deploy: search for a paper from this week returns one hit (month page), not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)