### PR TITLE
fix: stop rendering abstracts on paper cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Each JSON file is `{keyword: {arxiv_id: paper}}`, where `paper` is a record like
 }
 ```
 
-Papers fetched before September 2026 are stored as a one-line markdown string instead (title, first author, date, links only); the site renders both. The JSON files are stable and safe to consume directly if you want the data without the website.
+Papers fetched before September 2026 are stored as a one-line markdown string instead (title, first author, date, links only); the site renders both. Abstracts are not shown on the pages (they made list pages several MB) but are included in the `.bib` downloads and RSS feeds. The JSON files are stable and safe to consume directly if you want the data without the website.
 
 Code lives in `nlp_arxiv_daily/` (Python pipeline) and `web/` (Astro site).
 

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -88,14 +88,8 @@ const primaryCategory = parsed?.categories[0] ?? null;
         bibtex
       </button>
     </div>
-    {parsed.abstract && (
-      <details class="mt-1 text-sm">
-        <summary class="cursor-pointer text-(--color-muted) hover:text-(--color-accent) select-none">
-          Abstract
-        </summary>
-        <p class="mt-1 leading-relaxed text-(--color-fg)/90">{parsed.abstract}</p>
-      </details>
-    )}
+    {/* Abstracts are stored in the JSON and shipped in the .bib downloads and
+        RSS, but not rendered here: on a 1000+ card page they tripled the HTML. */}
     {/* COinS: lets the Zotero connector save every paper on the page.
         Zero-size span by design — Zotero reads the title attribute only. */}
     <span class="Z3988" title={coins} aria-hidden="true" data-pagefind-ignore></span>


### PR DESCRIPTION
## Summary
- Remove the collapsible Abstract block from paper cards. Abstracts remain in the JSON records and are still included in the `.bib` downloads and RSS feeds; they are just not rendered on list pages.

## Test plan
- [x] `NODE_ENV=production astro build` passes; zero `<details>` on the Latest page
- [x] Page sizes measured (see commit / PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)