### PR TITLE
Revert "feat: Latest page shows the last 7 days; current month gets an archive page"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - 🔎 **Full-text search** across every paper (powered by [Pagefind](https://pagefind.app))
 - 🏷️ **Keyword tabs** — NLP, LLM, RAG, Reasoning, Multimodal, Long Context, Code LLM, …
-- 🗓️ **Latest = the last 7 days**, with **monthly archives** (including the current month) going back to launch
+- 🗓️ **Monthly archives** going back to launch
 - 📡 **[RSS feed](https://monologg.kr/nlp-arxiv-daily/rss.xml)** for your reader of choice — plus one feed per keyword (e.g. [`/rss/rag.xml`](https://monologg.kr/nlp-arxiv-daily/rss/rag.xml), `/rss/llm-agent.xml`)
 - 📥 **BibTeX export** — per paper (copy button), per keyword, or the whole page / month as one `.bib` file (e.g. [`/bibtex/all.bib`](https://monologg.kr/nlp-arxiv-daily/bibtex/all.bib), `/bibtex/rag.bib`, `/archive/2026-08/all.bib`)
 - 🗂️ **Zotero-ready** — every list page embeds [COinS](https://en.wikipedia.org/wiki/COinS) metadata, so the Zotero connector can save all papers on a page in one click (as Preprint items with DOI, URL, and the keyword as a tag)

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -32,7 +32,7 @@ const primaryCategory = parsed?.categories[0] ?? null;
 
 {parsed ? (
   <article
-    class="paper-card py-3 border-b border-(--color-border) last:border-b-0"
+    class="py-3 border-b border-(--color-border) last:border-b-0"
     data-pagefind-body
   >
     <div class="flex items-baseline justify-between gap-3 mb-1">

--- a/web/src/pages/archive/[month].astro
+++ b/web/src/pages/archive/[month].astro
@@ -3,22 +3,21 @@ import Layout from "../../layouts/Layout.astro";
 import KeywordSection from "../../components/KeywordSection.astro";
 import TableOfContents from "../../components/TableOfContents.astro";
 import { withBase } from "../../utils/url.ts";
-import { allMonths, nonEmptyKeywords, type MonthEntry } from "../../utils/papers.ts";
+import { getCollection } from "astro:content";
 
-// Archive snapshots plus the live current month (not in the archive dir
-// until the month rolls over, but it's where the Latest page's "browse all
-// of this month" link points).
 export async function getStaticPaths() {
-  const months = await allMonths();
-  return months.map((entry) => ({
+  const entries = await getCollection("archive");
+  return entries.map((entry) => ({
     params: { month: entry.id },
     props: { entry },
   }));
 }
 
-const { entry } = Astro.props as { entry: MonthEntry };
+const { entry } = Astro.props;
 const data = entry.data;
-const keywords = nonEmptyKeywords(data);
+const keywords = Object.entries(data).filter(
+  ([, papers]) => Object.keys(papers).length > 0,
+);
 const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
   0,
@@ -42,7 +41,6 @@ const bibDir = `/archive/${entry.id}`;
       <h1 class="text-4xl font-bold mb-2">{entry.id}</h1>
       <p class="text-(--color-muted) text-sm">
         {totalPapers} papers across {keywords.length} keywords.
-        {entry.current && " Current month — grows with every 12-hour update."}
       </p>
       {keywords.length > 0 && (
         <p class="text-(--color-muted) text-sm mt-1">

--- a/web/src/pages/archive/[month]/[slug].bib.ts
+++ b/web/src/pages/archive/[month]/[slug].bib.ts
@@ -1,14 +1,15 @@
 import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
 import { buildBib } from "../../../utils/bibtex.ts";
 import { keywordSlug } from "../../../utils/keyword.ts";
-import { allMonths, nonEmptyKeywords, type KeywordEntries } from "../../../utils/papers.ts";
+import { nonEmptyKeywords, type KeywordEntries } from "../../../utils/papers.ts";
 
 /**
  * /archive/<YYYY-MM>/<keyword-slug>.bib — one keyword section of a month.
  * /archive/<YYYY-MM>/all.bib          — the whole month, de-duplicated.
  */
 export async function getStaticPaths() {
-  const entries = await allMonths();
+  const entries = await getCollection("archive");
   return entries.flatMap((entry) => {
     const keywords = nonEmptyKeywords(entry.data);
     const paths = keywords.map(([keyword, papers]) => ({

--- a/web/src/pages/archive/index.astro
+++ b/web/src/pages/archive/index.astro
@@ -1,12 +1,11 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { withBase } from "../../utils/url.ts";
-import { allMonths } from "../../utils/papers.ts";
+import { getCollection } from "astro:content";
 
-// Newest first; includes the live current month.
-const entries = await allMonths();
-const months = entries.map((e) => e.id);
-const currentId = entries.find((e) => e.current)?.id ?? null;
+const entries = await getCollection("archive");
+// Sort newest first.
+const months = entries.map((e) => e.id).sort().reverse();
 
 // Group by year so the long list is browsable on a dense screen.
 const byYear = new Map<string, string[]>();
@@ -36,7 +35,7 @@ for (const month of months) {
                 class="inline-block px-3 py-1 rounded border border-(--color-muted)/30 hover:border-(--color-accent) hover:text-(--color-accent) text-sm"
                 href={withBase(`/archive/${month}/`)}
               >
-                {month}{month === currentId && <span class="text-(--color-muted)"> · current</span>}
+                {month}
               </a>
             </li>
           ))}

--- a/web/src/pages/bibtex/[slug].bib.ts
+++ b/web/src/pages/bibtex/[slug].bib.ts
@@ -1,17 +1,15 @@
 import type { APIRoute } from "astro";
 import { buildBib } from "../../utils/bibtex.ts";
 import { keywordSlug } from "../../utils/keyword.ts";
-import { resolveRecent, type KeywordEntries } from "../../utils/papers.ts";
+import { resolveLatest, type KeywordEntries } from "../../utils/papers.ts";
 
 /**
- * /bibtex/<keyword-slug>.bib — one keyword section of the Latest page.
+ * /bibtex/<keyword-slug>.bib — every paper in one "Latest" keyword section.
  * /bibtex/all.bib          — the whole Latest page, de-duplicated.
- * Both cover the same day window the page shows; whole months live at
- * /archive/<YYYY-MM>/<slug>.bib.
  */
 export async function getStaticPaths() {
-  const { keywords, windowDays, since, monthId, widened } = await resolveRecent();
-  const label = widened ? `all of ${monthId}` : `last ${windowDays} days, since ${since}`;
+  const { keywords, fallbackMonth } = await resolveLatest();
+  const label = fallbackMonth ?? "latest";
   const paths = keywords.map(([keyword, papers]) => ({
     params: { slug: keywordSlug(keyword) },
     props: { buckets: [[keyword, papers]] as KeywordEntries, header: `NLP Arxiv Daily — ${keyword} (${label})` },

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,9 +4,9 @@ import KeywordFilter from "../components/KeywordFilter.astro";
 import KeywordSection from "../components/KeywordSection.astro";
 import TableOfContents from "../components/TableOfContents.astro";
 import { withBase } from "../utils/url.ts";
-import { resolveRecent } from "../utils/papers.ts";
+import { resolveLatest } from "../utils/papers.ts";
 
-const { keywords, windowDays, since, monthId, widened } = await resolveRecent();
+const { keywords, fallbackMonth } = await resolveLatest();
 
 const totalPapers = keywords.reduce(
   (sum, [, papers]) => sum + Object.keys(papers).length,
@@ -14,38 +14,30 @@ const totalPapers = keywords.reduce(
 );
 const today = new Date().toISOString().slice(0, 10);
 const bibDir = "/bibtex";
-const monthHref = monthId ? withBase(`/archive/${monthId}/`) : null;
 ---
 
 <Layout title="NLP Arxiv Daily" current="home">
-  {/* Pagefind indexes the month pages instead — the same papers would
-      otherwise show up twice in search results while they're recent. */}
-  <main class="max-w-3xl mx-auto px-6 py-10" data-pagefind-ignore="all">
+  <main class="max-w-3xl mx-auto px-6 py-10">
     <header class="mb-10">
       <h1 class="text-4xl font-bold mb-2">Updated {today}</h1>
-      {widened ? (
+      {fallbackMonth ? (
         <p class="text-(--color-muted) text-sm">
-          Nothing submitted in the last {windowDays} days yet — showing all of
-          {" "}{monthId} ({totalPapers} papers across {keywords.length} keywords).
+          No papers yet this month — showing the latest snapshot from
+          {" "}
+          <a class="hover:text-(--color-accent) hover:underline" href={withBase(`/archive/${fallbackMonth}/`)}>
+            {fallbackMonth}
+          </a>
+          {" "}({totalPapers} papers across {keywords.length} keywords).
         </p>
       ) : (
         <p class="text-(--color-muted) text-sm">
-          {totalPapers} papers across {keywords.length} keywords in the last {windowDays} days
-          (since {since}).
-          {monthHref && (
-            <>
-              {" "}
-              <a class="text-(--color-accent) hover:underline" href={monthHref}>
-                Browse all of {monthId} →
-              </a>
-            </>
-          )}
+          {totalPapers} papers across {keywords.length} keywords this month.
         </p>
       )}
       {keywords.length > 0 && (
         <p class="text-(--color-muted) text-sm mt-1">
           <a class="text-(--color-accent) hover:underline" href={withBase(`${bibDir}/all.bib`)} download>
-            Download this list as BibTeX
+            Download all as BibTeX
           </a>
           {" "}· <a class="text-(--color-accent) hover:underline" href={withBase("/rss.xml")}>RSS</a> (each keyword has its own feed, see section headers)
           {" "}· every paper on this page is also visible to the Zotero connector.

--- a/web/src/pages/og/[...slug].png.ts
+++ b/web/src/pages/og/[...slug].png.ts
@@ -1,7 +1,7 @@
 import { OGImageRoute } from "astro-og-canvas";
+import { getCollection } from "astro:content";
 import currentPapers from "../../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../../content.config.ts";
-import { allMonths } from "../../utils/papers.ts";
 
 interface OgPage {
   title: string;
@@ -21,9 +21,11 @@ const pages: Record<string, OgPage> = {
   },
 };
 
-// Add per-month archive cards (archive snapshots + the live current month).
-for (const entry of await allMonths()) {
-  const total = Object.values(entry.data).reduce(
+// Add per-month archive cards.
+const archiveEntries = await getCollection("archive");
+for (const entry of archiveEntries) {
+  const data = paperBucketSchema.parse(entry.data);
+  const total = Object.values(data).reduce(
     (sum, papers) => sum + Object.keys(papers).length,
     0,
   );

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -45,11 +45,3 @@ html.dark {
 body {
   transition: background-color 150ms ease, color 150ms ease;
 }
-
-/* Long lists (a whole month is 2000+ cards): let the browser skip layout
-   and paint for cards outside the viewport. The intrinsic size is a rough
-   collapsed-card height so the scrollbar stays stable. */
-.paper-card {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 5rem;
-}

--- a/web/src/utils/papers.ts
+++ b/web/src/utils/papers.ts
@@ -1,65 +1,13 @@
 import { getCollection } from "astro:content";
 import currentPapers from "../../../docs/nlp-arxiv-daily-web.json";
 import { paperBucketSchema } from "../content.config.ts";
-import { parsePaper, type PaperValue } from "./paperRow.ts";
+import type { PaperValue } from "./paperRow.ts";
 
 export type PaperBucket = Record<string, Record<string, PaperValue>>;
 export type KeywordEntries = Array<[string, Record<string, PaperValue>]>;
 
-/** Days of papers the Latest page shows. Forks can override at build time
- * with PUBLIC_LATEST_WINDOW_DAYS; the full month lives under /archive/. */
-export const LATEST_WINDOW_DAYS = Math.max(1, Number(import.meta.env.PUBLIC_LATEST_WINDOW_DAYS ?? 7) || 7);
-
 export function nonEmptyKeywords(data: PaperBucket): KeywordEntries {
   return Object.entries(data).filter(([, papers]) => Object.keys(papers).length > 0);
-}
-
-function totalRows(data: PaperBucket): number {
-  return Object.values(data).reduce((sum, papers) => sum + Object.keys(papers).length, 0);
-}
-
-/**
- * "YYYY-MM" for the current-month JSON, derived from its arxiv ids (the
- * pipeline buckets that file by id prefix, so the newest prefix is the
- * month). Null when the file is empty.
- */
-export function currentMonthId(data: PaperBucket): string | null {
-  let best: string | null = null;
-  for (const papers of Object.values(data)) {
-    for (const id of Object.keys(papers)) {
-      const m = id.match(/^(\d{2})(\d{2})\./);
-      if (!m) continue;
-      const ym = `20${m[1]}-${m[2]}`;
-      if (best === null || ym > best) best = ym;
-    }
-  }
-  return best;
-}
-
-export interface MonthEntry {
-  id: string; // "YYYY-MM"
-  data: PaperBucket;
-  /** True for the live current-month file (rebuilt every 12h). */
-  current: boolean;
-}
-
-/**
- * Every month we can render a page for: the archive snapshots plus the
- * current-month JSON (which is not in the archive until the month rolls
- * over). Newest first. Empty months are dropped.
- */
-export async function allMonths(): Promise<MonthEntry[]> {
-  const entries = await getCollection("archive");
-  const months: MonthEntry[] = entries
-    .filter((e) => totalRows(e.data) > 0)
-    .map((e) => ({ id: e.id, data: e.data, current: false }));
-
-  const currentData = paperBucketSchema.parse(currentPapers);
-  const currentId = currentMonthId(currentData);
-  if (currentId && !months.some((m) => m.id === currentId)) {
-    months.push({ id: currentId, data: currentData, current: true });
-  }
-  return months.sort((a, b) => b.id.localeCompare(a.id));
 }
 
 export interface LatestSnapshot {
@@ -71,10 +19,10 @@ export interface LatestSnapshot {
 }
 
 /**
- * The newest whole month: the current-month JSON, or — early in a month
- * before the cron has landed anything — the newest non-empty archive
- * snapshot. Used by the RSS feeds, which want more history than the
- * Latest page's day window.
+ * The "Latest" dataset: the current-month JSON, or — early in a month before
+ * the cron has landed anything — the newest non-empty archive snapshot.
+ * Shared by the index page and the BibTeX endpoints so both agree on what
+ * "latest" means.
  */
 export async function resolveLatest(): Promise<LatestSnapshot> {
   const currentData = paperBucketSchema.parse(currentPapers);
@@ -82,57 +30,16 @@ export async function resolveLatest(): Promise<LatestSnapshot> {
   if (currentKeywords.length > 0) {
     return { data: currentData, keywords: currentKeywords, fallbackMonth: null };
   }
-  const months = await allMonths();
-  if (months.length === 0) return { data: currentData, keywords: [], fallbackMonth: null };
-  return { data: months[0].data, keywords: nonEmptyKeywords(months[0].data), fallbackMonth: months[0].id };
-}
 
-export interface RecentSnapshot {
-  keywords: KeywordEntries;
-  windowDays: number;
-  /** ISO date (inclusive) the window starts at. */
-  since: string;
-  /** Month page that holds the full list the window was cut from. */
-  monthId: string | null;
-  /** True when the window held nothing and the whole newest month is shown. */
-  widened: boolean;
-}
+  const entries = await getCollection("archive");
+  const candidates = entries
+    .map((e) => ({ id: e.id, data: e.data, keywords: nonEmptyKeywords(e.data) }))
+    .filter((c) => c.keywords.length > 0)
+    .sort((a, b) => b.id.localeCompare(a.id));
 
-/**
- * The Latest page dataset: papers submitted in the last `days` days, across
- * the newest two months (so the window survives a month boundary). Keyword
- * order follows the current-month file, i.e. config.yaml. If the window is
- * empty (arxiv holiday, cron outage) the newest month is shown whole.
- */
-export async function resolveRecent(days: number = LATEST_WINDOW_DAYS): Promise<RecentSnapshot> {
-  const months = await allMonths();
-  if (months.length === 0) return { keywords: [], windowDays: days, since: "", monthId: null, widened: false };
-
-  const sinceDate = new Date();
-  sinceDate.setUTCDate(sinceDate.getUTCDate() - (days - 1));
-  const since = sinceDate.toISOString().slice(0, 10);
-
-  const merged: PaperBucket = {};
-  for (const month of months.slice(0, 2)) {
-    for (const [keyword, papers] of Object.entries(month.data)) {
-      const bucket = (merged[keyword] ??= {});
-      for (const [id, value] of Object.entries(papers)) {
-        if (id in bucket) continue;
-        const parsed = parsePaper(value);
-        if (parsed && parsed.date >= since) bucket[id] = value;
-      }
-    }
+  if (candidates.length === 0) {
+    return { data: currentData, keywords: [], fallbackMonth: null };
   }
-
-  const keywords = nonEmptyKeywords(merged);
-  if (keywords.length > 0) {
-    return { keywords, windowDays: days, since, monthId: months[0].id, widened: false };
-  }
-  return {
-    keywords: nonEmptyKeywords(months[0].data),
-    windowDays: days,
-    since,
-    monthId: months[0].id,
-    widened: true,
-  };
+  const latest = candidates[0];
+  return { data: latest.data, keywords: latest.keywords, fallbackMonth: latest.id };
 }


### PR DESCRIPTION
## Summary
- Reverts #73. The front page goes back to showing the whole current month, as it always did. The 7-day window was added to work around page size, and #74 (no abstracts on cards) already solved that.

## Test plan
- [x] `astro build` passes; Latest shows all 1974 cards for September, header says "papers across N keywords this month"

🤖 Generated with [Claude Code](https://claude.com/claude-code)