### PR TITLE
fix: daily fetch scans the last 7 days instead of the newest 10 per keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ arXiv API ──► fetcher ──► JSON snapshots ──► Astro static site
                               └──► docs/nlp-arxiv-daily-web.json + docs/archive-web/*.json
 ```
 
-A GitHub Actions cron runs every 12 hours: it queries arXiv per keyword, merges results into the monthly JSON archives, then triggers an Astro rebuild and deploy.
+A GitHub Actions cron runs every 12 hours: for each keyword it fetches every submission from the last 7 days (idempotent merge, so re-sightings are free), stores the results in the monthly JSON archives, then triggers an Astro rebuild and deploy.
 
 Each JSON file is `{keyword: {arxiv_id: paper}}`, where `paper` is a record like:
 
@@ -74,7 +74,8 @@ Set your GitHub username/repo and replace the `keywords` block with whatever you
 user_name: "your-github-username"
 repo_name: "your-fork-name"
 
-max_results: 10            # papers per keyword per fetch
+daily_lookback_days: 7     # each run re-scans the last N days per keyword
+max_results: 1500          # safety cap per keyword per run (not a target)
 publish_gitpage: True      # keep True so the website still builds
 
 keywords:

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,12 @@ repo_name: "nlp-arxiv-daily"
 show_authors: True
 show_links: True
 show_badge: False
-max_results: 10
+# Daily fetch = every submission in the last `daily_lookback_days` days per
+# keyword. `max_results` is only a safety cap on that query (LLM peaks around
+# 150/day). It used to be a top-10 newest-first query, which silently dropped
+# ~90% of high-volume keywords.
+daily_lookback_days: 7
+max_results: 1500
 
 publish_readme: False
 publish_gitpage: True

--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -18,31 +18,56 @@ import logging
 import sys
 from collections.abc import Iterator
 
-from nlp_arxiv_daily.core import get_daily_papers, load_config, papers_to_legacy_rows
+from nlp_arxiv_daily.core import load_config, papers_to_legacy_rows
 from nlp_arxiv_daily.fetcher import (
     BACKFILL_DEFAULT_MAX_RESULTS,
     BACKFILL_RATE_LIMIT_SECONDS,
+    DEFAULT_DAILY_LOOKBACK_DAYS,
     fetch_papers_in_range,
+    fetch_recent_papers,
 )
 from nlp_arxiv_daily.renderer import json_to_md, render_archive_pages
-from nlp_arxiv_daily.storage import write_papers_split
+from nlp_arxiv_daily.storage import load_known_code_links, write_papers_split
+
+
+def _known_code_links(config: dict) -> dict[str, str | None]:
+    """Stored code links for every persisted paper, across both JSON flavors."""
+    known: dict[str, str | None] = {}
+    if config["publish_readme"]:
+        known.update(load_known_code_links(config["json_readme_path"], config["archive_readme_json_dir"]))
+    if config["publish_gitpage"]:
+        for paper_id, link in load_known_code_links(
+            config["json_gitpage_path"], config["archive_gitpage_json_dir"]
+        ).items():
+            if paper_id not in known or link:
+                known[paper_id] = link
+    return known
 
 
 def cmd_fetch(config: dict) -> None:
-    """Query arxiv for every keyword in `config["kv"]`, persist JSON splits."""
+    """Query arxiv for every keyword in `config["kv"]` over the last
+    `daily_lookback_days` days, persist JSON splits."""
     keywords = config["kv"]
     max_results = config["max_results"]
+    lookback_days = int(config.get("daily_lookback_days", DEFAULT_DAILY_LOOKBACK_DAYS))
     keyword_order = list(keywords.keys())
+    known_code_links = _known_code_links(config)
 
     data_collector = []
     data_collector_web = []
 
-    logging.info("GET daily papers begin")
+    logging.info(f"GET daily papers begin (last {lookback_days} days, {len(known_code_links)} known papers)")
     failed_keywords: list[str] = []
     for topic, keyword in keywords.items():
         logging.info(f"Keyword: {topic}")
         try:
-            data, data_web = get_daily_papers(topic, query=keyword, max_results=max_results)
+            papers = fetch_recent_papers(
+                keyword,
+                lookback_days=lookback_days,
+                max_results=max_results,
+                known_code_links=known_code_links,
+            )
+            data, data_web = papers_to_legacy_rows(papers, topic)
         except Exception as e:
             # One keyword exhausting arxiv's retries (429/503 storm) must not
             # abort the whole daily run. write_papers_split merges onto existing
@@ -176,7 +201,11 @@ def cmd_backfill(
         logging.info(f"BACKFILL restricted to {len(keywords)} keyword(s): {list(keywords)}")
 
     months = list(_iter_month_ranges(start, end))
-    logging.info(f"BACKFILL begin: {start.isoformat()} → {end.isoformat()} ({len(months)} months)")
+    known_code_links = _known_code_links(config)
+    logging.info(
+        f"BACKFILL begin: {start.isoformat()} → {end.isoformat()} ({len(months)} months, "
+        f"{len(known_code_links)} known papers)"
+    )
 
     failed_queries: list[str] = []
     for month_start, month_end in months:
@@ -196,6 +225,7 @@ def cmd_backfill(
                     end=month_end,
                     max_results=max_results,
                     delay_seconds=delay_seconds,
+                    known_code_links=known_code_links,
                 )
             except Exception as e:
                 # One bad keyword × month must not kill the rest of the backfill.

--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import re
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import arxiv
 import requests
@@ -34,10 +34,14 @@ BACKFILL_RATE_LIMIT_SECONDS = 5
 # before our outer tenacity retry kicks in.
 DAILY_NUM_RETRIES = 10
 BACKFILL_NUM_RETRIES = 10
-# config caps display at max_results=10 per keyword, so a library-default
-# page_size=100 just inflates response payloads without giving us anything.
-# Smaller pages also reduce the chance of tripping arxiv's per-IP throttle.
-DAILY_PAGE_SIZE = 20
+# The daily fetch is a date-range query that can return several hundred
+# results for a busy keyword; full pages mean fewer (rate-limited) requests.
+DAILY_PAGE_SIZE = 100
+# The daily fetch covers the last N days (inclusive of today). arxiv announces
+# once per weekday and a submission can surface days later, so a window of a
+# week — merged idempotently — catches late announcements a top-N sorted
+# query silently missed (config.yaml `daily_lookback_days` overrides this).
+DEFAULT_DAILY_LOOKBACK_DAYS = 7
 # Default upper bound per (keyword, month) backfill query — busy keywords
 # can return hundreds of arxiv submissions in a single month.
 BACKFILL_DEFAULT_MAX_RESULTS = 2000
@@ -136,8 +140,12 @@ def _strip_version_suffix(short_id: str) -> str:
     return short_id if ver_pos == -1 else short_id[:ver_pos]
 
 
-def _result_to_paper(result) -> Paper:
+def _result_to_paper(result, known_code_links: Mapping[str, str | None] | None = None) -> Paper:
     """Convert an arxiv.Result to our Paper dataclass.
+
+    `known_code_links` ({paper_id: link_or_None} for papers already persisted)
+    short-circuits the HuggingFace Papers lookup: a re-sighted paper reuses
+    its stored link instead of costing another throttled HF request.
 
     Uses `result.published.date()` (submission date), NOT
     `result.updated.date()` (latest revision). Backfilled papers can have
@@ -159,13 +167,18 @@ def _result_to_paper(result) -> Paper:
 
     logging.info(f"Time = {update_time} title = {result.title} author = {first_author}")
 
+    if known_code_links is not None and paper_id in known_code_links:
+        code_link = known_code_links[paper_id]
+    else:
+        code_link = find_code_link(paper_id, summary=result.summary)
+
     return Paper(
         paper_id=paper_id,
         title=result.title,
         first_author=first_author,
         update_time=update_time,
         paper_url=result.entry_id,
-        code_link=find_code_link(paper_id, summary=result.summary),
+        code_link=code_link,
         arxiv_short_id=short_id,
         authors=authors,
         abstract=abstract,
@@ -212,6 +225,8 @@ def fetch_papers_in_range(
     end: datetime.date,
     max_results: int = BACKFILL_DEFAULT_MAX_RESULTS,
     delay_seconds: int = BACKFILL_RATE_LIMIT_SECONDS,
+    known_code_links: Mapping[str, str | None] | None = None,
+    client: arxiv.Client | None = None,
 ) -> list[Paper]:
     """
     Same as `fetch_papers`, but constrained to arxiv submissions in
@@ -228,9 +243,40 @@ def fetch_papers_in_range(
     )
     composite = f"({query}) AND {range_clause}"
 
-    client = arxiv.Client(
-        delay_seconds=delay_seconds,
-        num_retries=BACKFILL_NUM_RETRIES,
-    )
+    if client is None:
+        client = arxiv.Client(
+            delay_seconds=delay_seconds,
+            num_retries=BACKFILL_NUM_RETRIES,
+        )
     search = arxiv.Search(query=composite, max_results=max_results, sort_by=arxiv.SortCriterion.SubmittedDate)
-    return [_result_to_paper(r) for r in client.results(search)]
+    return [_result_to_paper(r, known_code_links) for r in client.results(search)]
+
+
+def fetch_recent_papers(
+    query: str,
+    *,
+    lookback_days: int = DEFAULT_DAILY_LOOKBACK_DAYS,
+    max_results: int,
+    known_code_links: Mapping[str, str | None] | None = None,
+    today: datetime.date | None = None,
+) -> list[Paper]:
+    """
+    The daily fetch: every submission matching `query` in the last
+    `lookback_days` days (today inclusive), via the shared daily client.
+
+    This replaced a `max_results=10` newest-first query in 2026-09: arxiv
+    announces once a day, so that cap was an effective 10 papers/day/keyword
+    and dropped ~90% of high-volume keywords (LLM: ~150/day). A date window
+    scales with volume; `max_results` is only a safety cap now.
+    """
+    if today is None:
+        today = datetime.date.today()
+    start = today - datetime.timedelta(days=max(lookback_days, 1) - 1)
+    return fetch_papers_in_range(
+        query,
+        start,
+        today,
+        max_results=max_results,
+        known_code_links=known_code_links,
+        client=_get_daily_client(),
+    )

--- a/nlp_arxiv_daily/records.py
+++ b/nlp_arxiv_daily/records.py
@@ -9,7 +9,14 @@ the pipeline fetches afterwards is a dict. `web_record_to_line` lets the
 
 from __future__ import annotations
 
+import re
+
 from nlp_arxiv_daily.types import Paper, PaperValue, WebRecord
+
+
+# Legacy rows carry the code link as `**[<text>](<url>)**` — bullet rows as
+# `Code: **[url](url)**`, README pipe rows as `|**[link](url)**|`.
+_LEGACY_CODE_RE = re.compile(r"\*\*\[[^\]]*\]\((https?://[^)]+)\)\*\*")
 
 
 def paper_to_web_record(p: Paper) -> WebRecord:
@@ -40,3 +47,12 @@ def web_record_to_line(value: PaperValue) -> str:
         return value
     authors = value.get("authors") or [""]
     return web_line(value["date"], value["title"], authors[0], value["url"], value.get("code"))
+
+
+def code_link_from_value(value: PaperValue) -> str | None:
+    """Code link already stored for a paper, from either value shape. Lets a
+    re-fetch reuse it instead of asking HuggingFace Papers again."""
+    if isinstance(value, dict):
+        return value.get("code") or None
+    m = _LEGACY_CODE_RE.search(value)
+    return m.group(1) if m else None

--- a/nlp_arxiv_daily/storage.py
+++ b/nlp_arxiv_daily/storage.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 
+from nlp_arxiv_daily.records import code_link_from_value
 from nlp_arxiv_daily.types import PapersByKeyword, PapersByMonth
 
 
@@ -47,6 +48,27 @@ def _load_papers_json(path: str, into: dict) -> None:
         return
     for kw, papers in json.loads(content).items():
         into.setdefault(kw, {}).update(papers)
+
+
+def load_known_code_links(main_json_path: str, archive_dir: str) -> dict[str, str | None]:
+    """{paper_id: code_link_or_None} for every paper already persisted (main +
+    archive). The fetcher skips the HuggingFace Papers lookup for these ids —
+    with a multi-day fetch window most results are re-sightings, and one HF
+    call per result was the dominant cost of a run."""
+    accumulated: PapersByKeyword = {}
+    _load_papers_json(main_json_path, accumulated)
+    if os.path.isdir(archive_dir):
+        for name in sorted(os.listdir(archive_dir)):
+            if name.endswith(".json"):
+                _load_papers_json(os.path.join(archive_dir, name), accumulated)
+    known: dict[str, str | None] = {}
+    for papers in accumulated.values():
+        for paper_id, value in papers.items():
+            link = code_link_from_value(value)
+            # A link seen under any keyword wins over None from another.
+            if paper_id not in known or link:
+                known[paper_id] = link
+    return known
 
 
 def _ordered_bucket(bucket: PapersByKeyword, keyword_order: list[str] | None) -> PapersByKeyword:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,24 +151,37 @@ class TestCmdFetchResilience:
             "archive_gitpage_json_dir": str(archive_web_dir),
         }
 
+    @staticmethod
+    def _paper(topic):
+        # YYMM prefix must match the current month so it lands in main-web.json
+        # (not the archive). bucket_by_month buckets by the id's YYMM prefix.
+        import datetime
+
+        from nlp_arxiv_daily.types import Paper
+
+        today = datetime.date.today()
+        key = f"{today.year % 100:02d}{today.month:02d}.00001"
+        return Paper(
+            paper_id=key,
+            title=f"{topic} paper",
+            first_author="A",
+            update_time=today,
+            paper_url=f"http://arxiv.org/abs/{key}v1",
+            code_link=None,
+            arxiv_short_id=f"{key}v1",
+        )
+
     def test_one_keyword_failure_does_not_abort_run(self, monkeypatch, tmp_path):
         import json
 
         import arxiv
 
-        def fake_get_daily_papers(topic, query, max_results):
-            if topic == "NLP":
+        def fake_fetch_recent(query, **kw):
+            if query == "NLP":
                 raise arxiv.HTTPError("https://export.arxiv.org/api/query", 1, 429)
-            # YYMM prefix must match the current month so it lands in main-web.json
-            # (not the archive). bucket_by_month buckets by the id's YYMM prefix.
-            import datetime
+            return [self._paper(query)]
 
-            today = datetime.date.today()
-            key = f"{today.year % 100:02d}{today.month:02d}.00001"
-            row = {topic: {key: "ok\n"}}
-            return row, row
-
-        monkeypatch.setattr(cli, "get_daily_papers", fake_get_daily_papers)
+        monkeypatch.setattr(cli, "fetch_recent_papers", fake_fetch_recent)
 
         config = self._config(tmp_path)
         # Must not raise even though NLP keyword 429s.
@@ -182,13 +195,77 @@ class TestCmdFetchResilience:
     def test_all_keywords_failing_raises(self, monkeypatch, tmp_path):
         import arxiv
 
-        def boom(topic, query, max_results):
+        def boom(query, **kw):
             raise arxiv.HTTPError("https://export.arxiv.org/api/query", 1, 503)
 
-        monkeypatch.setattr(cli, "get_daily_papers", boom)
+        monkeypatch.setattr(cli, "fetch_recent_papers", boom)
 
         with pytest.raises(RuntimeError, match="all .* keyword fetches failed"):
             cli.cmd_fetch(self._config(tmp_path))
+
+
+class TestCmdFetchWindow:
+    """The daily fetch is a date-range query (last N days), not a top-N —
+    a top-10 cap silently dropped ~90% of high-volume keywords (2026-09)."""
+
+    def test_passes_lookback_cap_and_known_links(self, monkeypatch, tmp_path):
+        import json
+
+        json_dir = tmp_path / "docs"
+        json_dir.mkdir()
+        archive_web_dir = json_dir / "archive-web"
+        archive_web_dir.mkdir()
+        (json_dir / "main-web.json").write_text(
+            json.dumps(
+                {
+                    "NLP": {
+                        "2609.00001": "- 2026-09-01, **Old**, A et.al., Paper: [u](u), Code: **[https://github.com/o/o](https://github.com/o/o)**\n"
+                    }
+                }
+            )
+        )
+        config = {
+            "kv": {"NLP": "all:NLP"},
+            "max_results": 1000,
+            "daily_lookback_days": 5,
+            "publish_readme": False,
+            "publish_gitpage": True,
+            "json_gitpage_path": str(json_dir / "main-web.json"),
+            "archive_gitpage_json_dir": str(archive_web_dir),
+        }
+        calls = []
+
+        def fake_fetch_recent(query, **kw):
+            calls.append((query, kw))
+            return []
+
+        monkeypatch.setattr(cli, "fetch_recent_papers", fake_fetch_recent)
+        cli.cmd_fetch(config)
+        assert len(calls) == 1
+        query, kw = calls[0]
+        assert query == "all:NLP"
+        assert kw["lookback_days"] == 5
+        assert kw["max_results"] == 1000
+        assert kw["known_code_links"] == {"2609.00001": "https://github.com/o/o"}
+
+    def test_lookback_defaults_when_config_omits_it(self, monkeypatch, tmp_path):
+        json_dir = tmp_path / "docs"
+        json_dir.mkdir()
+        (json_dir / "main-web.json").write_text("{}")
+        config = {
+            "kv": {"NLP": "all:NLP"},
+            "max_results": 1000,
+            "publish_readme": False,
+            "publish_gitpage": True,
+            "json_gitpage_path": str(json_dir / "main-web.json"),
+            "archive_gitpage_json_dir": str(json_dir / "archive-web"),
+        }
+        seen = {}
+        monkeypatch.setattr(cli, "fetch_recent_papers", lambda query, **kw: seen.update(kw) or [])
+        cli.cmd_fetch(config)
+        from nlp_arxiv_daily.fetcher import DEFAULT_DAILY_LOOKBACK_DAYS
+
+        assert seen["lookback_days"] == DEFAULT_DAILY_LOOKBACK_DAYS
 
 
 class TestCmdRunInvocation:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -43,7 +43,12 @@ class _FakeClient:
         self._results_by_query = results_by_query
 
     def results(self, search):
-        return iter(self._results_by_query.get(search.query, []))
+        # The daily fetch wraps the keyword query in a submittedDate range
+        # ("(all:NLP) AND submittedDate:[...]"), so match by substring.
+        for key, papers in self._results_by_query.items():
+            if key in search.query:
+                return iter(papers)
+        return iter([])
 
 
 @pytest.fixture

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -365,10 +365,10 @@ class TestFetchPapersSharedClient:
         assert kwargs.get("delay_seconds", 0) >= 15
         # Library default is 3; bump so transient 429 storms don't kill the run.
         assert kwargs.get("num_retries", 0) >= 10
-        # page_size caps response payload size — config asks for max_results=10
-        # per keyword, so 100 (library default) wastes bandwidth and is more
-        # likely to trip arxiv's per-IP throttle.
-        assert kwargs.get("page_size", 100) <= 20
+        # The daily fetch is a date-range query returning up to a few hundred
+        # results per keyword; full pages keep the number of (rate-limited)
+        # requests down.
+        assert kwargs.get("page_size", 100) == fetcher.DAILY_PAGE_SIZE == 100
 
     def test_shares_client_across_calls(self, monkeypatch):
         _silence_code_link(monkeypatch)
@@ -607,3 +607,50 @@ class TestGetDailyPapersWebRecords:
         assert rec["date"] == "2026-04-22"
         assert rec["url"] == "http://arxiv.org/abs/2604.21637v2"
         assert rec["code"] is None
+
+
+class TestKnownCodeLinksSkipLookup:
+    def test_known_id_reuses_stored_link_without_hf_call(self, monkeypatch):
+        from nlp_arxiv_daily.fetcher import _result_to_paper
+
+        def boom(*a, **kw):
+            raise AssertionError("find_code_link must not be called for a known id")
+
+        monkeypatch.setattr(fetcher, "find_code_link", boom)
+        r = _FakeArxivResult(short_id="2604.21637v1")
+        p = _result_to_paper(r, known_code_links={"2604.21637": "https://github.com/k/v"})
+        assert p.code_link == "https://github.com/k/v"
+        p2 = _result_to_paper(r, known_code_links={"2604.21637": None})
+        assert p2.code_link is None
+
+    def test_unknown_id_still_looks_up(self, monkeypatch):
+        from nlp_arxiv_daily.fetcher import _result_to_paper
+
+        monkeypatch.setattr(fetcher, "find_code_link", lambda *a, **kw: "https://github.com/new/one")
+        p = _result_to_paper(_FakeArxivResult(short_id="2604.21637v1"), known_code_links={"other": None})
+        assert p.code_link == "https://github.com/new/one"
+
+
+class TestFetchRecentPapers:
+    def test_queries_a_lookback_window_ending_today(self, monkeypatch):
+        from nlp_arxiv_daily.fetcher import fetch_recent_papers
+
+        _silence_code_link(monkeypatch)
+        captured = _patch_arxiv(monkeypatch, [_FakeArxivResult(short_id="2609.00001v1")])
+        today = datetime.date(2026, 9, 8)
+        papers = fetch_recent_papers("all:NLP", lookback_days=7, max_results=500, today=today)
+        assert [p.paper_id for p in papers] == ["2609.00001"]
+        q = captured["search"].query
+        assert q.startswith("(all:NLP) AND submittedDate:[202609020000 TO 202609082359]")
+        assert captured["search"].max_results == 500
+        # Shared daily client: polite delay + big pages, not the backfill client.
+        assert captured["client_kwargs"]["delay_seconds"] == fetcher.DAILY_RATE_LIMIT_SECONDS
+        assert captured["client_kwargs"]["page_size"] == 100
+
+    def test_lookback_of_one_day_is_today_only(self, monkeypatch):
+        from nlp_arxiv_daily.fetcher import fetch_recent_papers
+
+        _silence_code_link(monkeypatch)
+        captured = _patch_arxiv(monkeypatch, [])
+        fetch_recent_papers("x", lookback_days=1, max_results=10, today=datetime.date(2026, 9, 8))
+        assert "submittedDate:[202609080000 TO 202609082359]" in captured["search"].query

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -78,3 +78,28 @@ class TestWebRecordToLine:
     def test_record_with_code_link(self):
         line = web_record_to_line(paper_to_web_record(_paper(code_link="https://github.com/x/y")))
         assert line.endswith(", Code: **[https://github.com/x/y](https://github.com/x/y)**\n")
+
+
+class TestCodeLinkFromValue:
+    def test_dict_record(self):
+        from nlp_arxiv_daily.records import code_link_from_value
+
+        assert code_link_from_value({"code": "https://github.com/x/y"}) == "https://github.com/x/y"
+        assert code_link_from_value({"code": None}) is None
+
+    def test_bullet_row(self):
+        from nlp_arxiv_daily.records import code_link_from_value
+
+        row = (
+            "- 2026-04-22, **T**, A et.al., Paper: [u](u), Code: **[https://github.com/x/y](https://github.com/x/y)**\n"
+        )
+        assert code_link_from_value(row) == "https://github.com/x/y"
+        assert code_link_from_value("- 2026-04-22, **T**, A et.al., Paper: [u](u)\n") is None
+
+    def test_pipe_row(self):
+        from nlp_arxiv_daily.records import code_link_from_value
+
+        assert code_link_from_value("|**2025-06-03**|**T**|A et.al.|[id](u)|**[link](https://github.com/x/y)**|\n") == (
+            "https://github.com/x/y"
+        )
+        assert code_link_from_value("|**2025-06-03**|**T**|A et.al.|[id](u)|null|\n") is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -237,3 +237,50 @@ class TestWebRecordsStorage:
         out = json.loads(main.read_text())
         assert out["NLP"]["2604.00001"] == record
         assert out["NLP"]["2604.00002"].startswith("- 2026-04-22, **Keep**")
+
+
+class TestLoadKnownCodeLinks:
+    def test_collects_ids_and_links_across_main_and_archive(self, tmp_path):
+        from nlp_arxiv_daily.storage import load_known_code_links
+
+        main = tmp_path / "main.json"
+        archive = tmp_path / "archive"
+        archive.mkdir()
+        main.write_text(
+            json.dumps(
+                {
+                    "NLP": {
+                        "2609.00001": {
+                            "date": "2026-09-01",
+                            "title": "A",
+                            "authors": ["x"],
+                            "url": "u",
+                            "code": "https://github.com/a/a",
+                            "abstract": "",
+                            "categories": [],
+                        },
+                        "2609.00002": "- 2026-09-02, **B**, y et.al., Paper: [u](u)\n",
+                    }
+                }
+            )
+        )
+        (archive / "2026-08.json").write_text(
+            json.dumps(
+                {
+                    "LLM": {
+                        "2608.00009": "- 2026-08-09, **C**, z et.al., Paper: [u](u), Code: **[https://github.com/c/c](https://github.com/c/c)**\n"
+                    }
+                }
+            )
+        )
+        known = load_known_code_links(str(main), str(archive))
+        assert known == {
+            "2609.00001": "https://github.com/a/a",
+            "2609.00002": None,
+            "2608.00009": "https://github.com/c/c",
+        }
+
+    def test_missing_files_give_empty(self, tmp_path):
+        from nlp_arxiv_daily.storage import load_known_code_links
+
+        assert load_known_code_links(str(tmp_path / "nope.json"), str(tmp_path / "nodir")) == {}


### PR DESCRIPTION
## Bug
The cron fetched `max_results: 10`, newest-first, per keyword — unchanged since the 2023 config. arxiv announces once per weekday, so both daily runs saw the same top 10 and everything below it was never fetched again. Once the LLM-era keywords landed (LLM alone is 100–200 submissions/day) cron-only months captured ~10%:

| month | LLM rows | total rows | source |
|---|---|---|---|
| 2026-01 … 04 | 1,893 – 2,255 | 4,889 – 5,665 | backfill |
| 2026-05 … 08 | 210 – 231 | 3,208 – 3,781 | cron only |

Per-cron-commit diff in September: exactly 10 new LLM rows per weekday, 0 on the second daily run, 0 on weekends.

## Fix
- `fetch_recent_papers()`: a `submittedDate` window of the last `daily_lookback_days` days (config, default 7) ending today, through the shared daily client (page_size 100, 15 s delay, 10 retries). `max_results` becomes a safety cap (set to 1500). Merging is idempotent, so re-sighting the same papers every day is free.
- Known code links: `cmd_fetch` and `cmd_backfill` load `{paper_id: code_link}` from the persisted JSON and skip the HuggingFace Papers lookup for papers already seen, so a wider window does not multiply HF calls. Legacy string rows are parsed for their link too.
- README fork guide and `config.yaml` updated.

Follow-up: backfill 2026-05 … 08 to repair the affected months (chunked local run, separate data PR).

## Test plan
- [x] TDD: new tests for `fetch_recent_papers` window/cap/client, known-link short-circuit, `code_link_from_value`, `load_known_code_links`, `cmd_fetch` wiring; existing resilience and e2e tests adapted to the range query
- [x] `make test`: 162 passed, coverage 95%; `make quality` clean
- [ ] Next cron run: per-keyword counts jump to the real daily volume and the run finishes in reasonable time (expect ~10–15 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)