### PR TITLE
feat: Latest header with key figures and actions; per-section truncation cues with in-place load more

### DIFF
--- a/web/src/components/KeywordSection.astro
+++ b/web/src/components/KeywordSection.astro
@@ -3,6 +3,7 @@ import PaperCard from "./PaperCard.astro";
 import { sortPapersDesc, type PaperValue } from "../utils/paperRow.ts";
 import { keywordSlug } from "../utils/keyword.ts";
 import { withBase } from "../utils/url.ts";
+import { PAGE_SIZE } from "../utils/papers.ts";
 
 interface Props {
   keyword: string;
@@ -13,7 +14,9 @@ interface Props {
   /** Show the per-keyword RSS link (Latest page only — archive months are
    * frozen, so a feed for them would never update). */
   rss?: boolean;
-  /** Render only the newest `limit` papers and link to `moreHref` for the rest. */
+  /** Render only the newest `limit` papers; the rest are reachable through
+   * `moreHref` (the keyword's month page), which the load-more script also
+   * fetches to append cards in place. */
   limit?: number;
   moreHref?: string;
 }
@@ -21,17 +24,31 @@ interface Props {
 const { keyword, papers, bibDir, rss = false, limit, moreHref } = Astro.props;
 const slug = keywordSlug(keyword);
 const all = sortPapersDesc(papers);
-const ordered = limit ? all.slice(0, limit) : all;
-const hidden = all.length - ordered.length;
+const total = all.length;
+// Never hide just one paper: the "view all" row would take the same space
+// as the card it replaces (Baymard truncation guideline #6).
+const truncate = Boolean(limit && moreHref) && total > (limit ?? 0) + 1;
+const ordered = truncate ? all.slice(0, limit) : all;
+const hidden = total - ordered.length;
+const pages = Math.ceil(total / PAGE_SIZE);
 const bibHref = bibDir ? withBase(`${bibDir}/${slug}.bib`) : null;
 const rssHref = rss ? withBase(`/rss/${slug}.xml`) : null;
+const fmt = (n: number) => n.toLocaleString("en-US");
 ---
 
 <section id={slug} class="mb-12 scroll-mt-20">
-  <header class="flex items-baseline justify-between mb-3 pb-2 border-b border-(--color-muted)/30">
+  <header class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-3 pb-2 border-b border-(--color-muted)/30">
     <h2 class="text-2xl font-semibold">{keyword}</h2>
     <span class="text-(--color-muted) text-sm flex items-center gap-3">
-      <span>{all.length} paper{all.length === 1 ? "" : "s"}</span>
+      {truncate ? (
+        <span>
+          Showing {fmt(ordered.length)} of <strong class="font-semibold text-(--color-fg) tabular-nums">{fmt(total)}</strong>
+          {" · "}
+          <a class="text-(--color-accent) hover:underline font-medium" href={moreHref} data-pagefind-ignore>View all →</a>
+        </span>
+      ) : (
+        <span><span class="tabular-nums">{fmt(total)}</span> paper{total === 1 ? "" : "s"}</span>
+      )}
       {bibHref && (
         <a
           class="text-(--color-accent) hover:underline"
@@ -55,15 +72,95 @@ const rssHref = rss ? withBase(`/rss/${slug}.xml`) : null;
       )}
     </span>
   </header>
-  {ordered.map(([paperId, row]) => (
-    <PaperCard paperId={paperId} row={row} keyword={keyword} />
-  ))}
-  {hidden > 0 && moreHref && (
-    <p class="mt-3 text-sm">
-      <a class="text-(--color-accent) hover:underline" href={moreHref} data-pagefind-ignore>
-        Show all {all.length} {keyword} papers →
+
+  <div class:list={["paper-list", truncate && "paper-list--truncated"]} data-paper-list>
+    {ordered.map(([paperId, row]) => (
+      <PaperCard paperId={paperId} row={row} keyword={keyword} />
+    ))}
+  </div>
+
+  {truncate && (
+    <div class="mt-3" data-pagefind-ignore>
+      <a
+        class="load-more flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded border border-(--color-border) text-(--color-accent) font-medium hover:border-(--color-accent) hover:bg-(--color-surface) transition-colors"
+        href={moreHref}
+        data-load-more
+        data-base={moreHref}
+        data-keyword={keyword}
+        data-total={total}
+        data-shown={ordered.length}
+        data-page-size={PAGE_SIZE}
+        data-pages={pages}
+      >
+        <span data-load-more-label>View all {fmt(total)} {keyword} papers</span>
+        <span class="text-(--color-muted) font-normal" data-load-more-hint>({fmt(hidden)} more)</span>
+        <span aria-hidden="true">→</span>
       </a>
-      <span class="text-(--color-muted)"> ({hidden} more)</span>
-    </p>
+    </div>
   )}
 </section>
+
+<script>
+  // Progressive enhancement for the per-section "View all" row. Without
+  // JS it is a plain link to the keyword's month page. With JS, a click
+  // fetches that (static) page, lifts its cards out and appends them in
+  // place, one page of PAGE_SIZE at a time — so a reader who wants the
+  // whole month never has to leave the Latest page, and nothing hidden
+  // behind navigation can be missed. Cards fetched later are plain HTML,
+  // so the delegated "bibtex" copy button keeps working for them.
+  const fmt = (n: number) => n.toLocaleString("en-US");
+
+  document.addEventListener("click", async (event) => {
+    const btn = (event.target as HTMLElement).closest<HTMLAnchorElement>("a[data-load-more]");
+    if (!btn || btn.dataset.busy) return;
+    event.preventDefault();
+
+    const base = btn.dataset.base!;
+    const total = Number(btn.dataset.total);
+    const pageSize = Number(btn.dataset.pageSize);
+    const pages = Number(btn.dataset.pages);
+    let shown = Number(btn.dataset.shown);
+    const section = btn.closest("section")!;
+    const list = section.querySelector<HTMLElement>("[data-paper-list]")!;
+    const label = btn.querySelector<HTMLElement>("[data-load-more-label]")!;
+    const hint = btn.querySelector<HTMLElement>("[data-load-more-hint]")!;
+
+    // Which static page holds the next card, and how many of that page's
+    // cards are already on screen.
+    const page = Math.floor(shown / pageSize) + 1;
+    const skip = shown % pageSize;
+    const url = page === 1 ? base : `${base}${page}/`;
+
+    btn.dataset.busy = "1";
+    const prevLabel = label.textContent;
+    label.textContent = "Loading…";
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`${res.status} ${url}`);
+      const doc = new DOMParser().parseFromString(await res.text(), "text/html");
+      const cards = Array.from(doc.querySelectorAll<HTMLElement>("article.paper-card")).slice(skip);
+      if (cards.length === 0) throw new Error(`no cards found in ${url}`);
+      for (const card of cards) list.appendChild(document.adoptNode(card));
+      shown += cards.length;
+      btn.dataset.shown = String(shown);
+    } catch (err) {
+      // Fall back to plain navigation — the link target is the same list.
+      console.error(err);
+      window.location.href = base;
+      return;
+    } finally {
+      delete btn.dataset.busy;
+    }
+
+    const remaining = total - shown;
+    if (remaining <= 0 || page >= pages) {
+      list.classList.remove("paper-list--truncated");
+      btn.parentElement!.remove();
+      return;
+    }
+    const nextChunk = Math.min(pageSize, remaining);
+    label.textContent = `Load ${fmt(nextChunk)} more`;
+    hint.textContent = `(${fmt(remaining)} remaining of ${fmt(total)})`;
+    if (prevLabel === null) label.textContent = "";
+  });
+</script>

--- a/web/src/components/LatestHeader.astro
+++ b/web/src/components/LatestHeader.astro
@@ -1,0 +1,80 @@
+---
+/**
+ * Latest page header: title, one line of key figures, one row of page
+ * actions. Figures are static data (bold numbers, muted labels — never
+ * styled like controls); actions reuse the outlined pill the keyword
+ * filter already uses, so the page keeps a single visual language.
+ */
+import { withBase } from "../utils/url.ts";
+
+interface Props {
+  today: string;
+  totalPapers: number;
+  keywordCount: number;
+  perKeyword: number;
+  monthId: string | null;
+  /** True when the current month was empty and an older snapshot is shown. */
+  fallbackMonth: string | null;
+  bibHref: string;
+}
+
+const { today, totalPapers, keywordCount, perKeyword, monthId, fallbackMonth, bibHref } = Astro.props;
+const fmt = (n: number) => n.toLocaleString("en-US");
+const monthLabel = monthId
+  ? new Date(`${monthId}-01T00:00:00Z`).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" })
+  : null;
+const pill =
+  "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded border border-(--color-border) hover:border-(--color-accent) hover:text-(--color-accent) transition-colors";
+---
+
+<header class="mb-8">
+  <h1 class="text-4xl font-bold mb-3">Updated {today}</h1>
+
+  {fallbackMonth ? (
+    <p class="text-(--color-muted) text-sm mb-4">
+      No papers yet this month — showing the latest snapshot from
+      {" "}
+      <a class="text-(--color-accent) hover:underline" href={withBase(`/archive/${fallbackMonth}/`)}>{fallbackMonth}</a>.
+    </p>
+  ) : null}
+
+  <p class="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-(--color-muted) text-sm mb-4">
+    <span><strong class="text-(--color-fg) text-base font-semibold tabular-nums">{fmt(totalPapers)}</strong> papers</span>
+    <span aria-hidden="true">·</span>
+    <span><strong class="text-(--color-fg) text-base font-semibold tabular-nums">{fmt(keywordCount)}</strong> keywords</span>
+    {monthLabel && (
+      <>
+        <span aria-hidden="true">·</span>
+        <span>{monthLabel}</span>
+      </>
+    )}
+    <span aria-hidden="true">·</span>
+    <span>newest <strong class="text-(--color-fg) font-semibold tabular-nums">{fmt(perKeyword)}</strong> shown per keyword</span>
+  </p>
+
+  <div class="flex flex-wrap items-center gap-2" data-pagefind-ignore>
+    <a class={pill} href={bibHref} download title="Every paper on this page, as one .bib file">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4" aria-hidden="true">
+        <path d="M12 3v12" /><path d="m7 10 5 5 5-5" /><path d="M5 21h14" />
+      </svg>
+      Download BibTeX
+    </a>
+    <a class={pill} href={withBase("/rss.xml")} title="Subscribe to every keyword; each section header also has its own feed">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4" aria-hidden="true">
+        <path d="M4 11a9 9 0 0 1 9 9" /><path d="M4 4a16 16 0 0 1 16 16" /><circle cx="5" cy="19" r="1" fill="currentColor" />
+      </svg>
+      RSS feed
+    </a>
+    <span
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded bg-(--color-surface) text-(--color-muted) cursor-help"
+      tabindex="0"
+      title="Every paper on this page carries COinS metadata, so the Zotero connector can save them all in one click."
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4" aria-hidden="true">
+        <circle cx="12" cy="12" r="9" /><path d="M12 16v-4" /><path d="M12 8h.01" />
+      </svg>
+      Zotero-ready
+      <span class="sr-only">: every paper on this page carries COinS metadata, so the Zotero connector can save them all in one click.</span>
+    </span>
+  </div>
+</header>

--- a/web/src/components/PaperCard.astro
+++ b/web/src/components/PaperCard.astro
@@ -32,7 +32,7 @@ const primaryCategory = parsed?.categories[0] ?? null;
 
 {parsed ? (
   <article
-    class="py-3 border-b border-(--color-border) last:border-b-0"
+    class="paper-card py-3 border-b border-(--color-border) last:border-b-0"
     data-pagefind-body
   >
     <div class="flex items-baseline justify-between gap-3 mb-1">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import KeywordFilter from "../components/KeywordFilter.astro";
 import KeywordSection from "../components/KeywordSection.astro";
+import LatestHeader from "../components/LatestHeader.astro";
 import TableOfContents from "../components/TableOfContents.astro";
 import { withBase } from "../utils/url.ts";
 import { keywordSlug } from "../utils/keyword.ts";
@@ -15,40 +16,21 @@ const totalPapers = keywords.reduce(
 );
 const today = new Date().toISOString().slice(0, 10);
 const bibDir = "/bibtex";
-const monthHref = monthId ? withBase(`/archive/${monthId}/`) : null;
 ---
 
 <Layout title="NLP Arxiv Daily" current="home">
   {/* Search indexes the keyword month pages, which hold every paper; the
       Latest page would only duplicate them. */}
   <main class="max-w-3xl mx-auto px-6 py-10" data-pagefind-ignore="all">
-    <header class="mb-10">
-      <h1 class="text-4xl font-bold mb-2">Updated {today}</h1>
-      {fallbackMonth ? (
-        <p class="text-(--color-muted) text-sm">
-          No papers yet this month — showing the latest snapshot from
-          {" "}
-          <a class="hover:text-(--color-accent) hover:underline" href={monthHref!}>
-            {fallbackMonth}
-          </a>
-          {" "}({totalPapers} papers across {keywords.length} keywords).
-        </p>
-      ) : (
-        <p class="text-(--color-muted) text-sm">
-          {totalPapers} papers across {keywords.length} keywords this month.
-          Each section shows the newest {LATEST_PER_KEYWORD}; follow a section's link for the full list.
-        </p>
-      )}
-      {keywords.length > 0 && (
-        <p class="text-(--color-muted) text-sm mt-1">
-          <a class="text-(--color-accent) hover:underline" href={withBase(`${bibDir}/all.bib`)} download>
-            Download all as BibTeX
-          </a>
-          {" "}· <a class="text-(--color-accent) hover:underline" href={withBase("/rss.xml")}>RSS</a> (each keyword has its own feed, see section headers)
-          {" "}· every paper on this page is also visible to the Zotero connector.
-        </p>
-      )}
-    </header>
+    <LatestHeader
+      today={today}
+      totalPapers={totalPapers}
+      keywordCount={keywords.length}
+      perKeyword={LATEST_PER_KEYWORD}
+      monthId={monthId}
+      fallbackMonth={fallbackMonth}
+      bibHref={withBase(`${bibDir}/all.bib`)}
+    />
 
     {keywords.length > 0 ? (
       <>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -45,3 +45,29 @@ html.dark {
 body {
   transition: background-color 150ms ease, color 150ms ease;
 }
+
+/* Truncated keyword sections on the Latest page: fade the tail of the list
+   into the page background so the reader can see it continues, right
+   above the "View all / Load more" row (Baymard truncation guideline #5). */
+.paper-list--truncated {
+  position: relative;
+}
+.paper-list--truncated::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 7rem;
+  background: linear-gradient(to bottom, transparent, var(--color-bg));
+  pointer-events: none;
+}
+
+/* Long lists (a keyword month page is 200 cards, and load-more can grow a
+   Latest section to a whole month): let the browser skip layout and paint
+   for cards outside the viewport. The intrinsic size is a rough card
+   height so the scrollbar stays stable. */
+.paper-card {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 5rem;
+}


### PR DESCRIPTION
## Summary
**Header.** Title, then one line of key figures (bold numbers, muted labels; static, not styled like controls), then a row of page actions reusing the outlined pill the keyword filter already uses: *Download BibTeX*, *RSS feed*, and a static *Zotero-ready* tag with a tooltip. Follows the page-header pattern (title / key information / actions) from Atlassian AUI and SAP Fiori; buttons for actions, one emphasis level, no filled primary since reading is the page's main task.

**Truncation cues, where the truncation happens.** A truncated section now:
- says `Showing 50 of 678 · View all →` in its header (visible before scrolling),
- fades the tail of the list into the page background (Baymard truncation guideline #5),
- ends with a full-width `View all 678 LLM papers (628 more) →` row.
- Sections that would hide a single paper are not truncated (guideline #6).

**Load more in place (progressive enhancement).** The row is a plain link to the keyword's month page. With JS, a click fetches that static page, lifts its `article.paper-card` elements and appends them, 200 at a time (`Load 200 more · 478 remaining of 678`), until the whole month is on the Latest page; then the row and the fade disappear. No new routes, no JS card template, and the delegated `bibtex` copy button works on appended cards. Any fetch problem falls back to normal navigation.

Also restores `.paper-card` + `content-visibility: auto` that the #73 revert removed.

## Test plan
- [x] `astro build` passes; Latest 1.85 MB, 786 cards
- [x] Headless Chrome (puppeteer-core) on `astro preview`: LLM section 50 → 200 → 400 → 600 → 678 over four clicks, label/hint update each time, row and fade removed at the end, zero console/page errors; appended cards carry `data-bibtex` and COinS
- [x] Sections with ≤1 hidden paper render untruncated (`38 papers`, `50 papers`, `45 papers`)
- [x] Screenshots of header and section tail reviewed
- [ ] After deploy: without JS, the row navigates to `/archive/2026-09/llm/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)