### PR TITLE
feat(backfill): --window-days splits a month so busy keywords aren't capped

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ Each `filters` entry is an arXiv search query — phrases are quoted and OR'd to
 ### 5. (Optional) Backfill historical months
 
 ```bash
-uv run python -m nlp_arxiv_daily backfill --start 2024-01 --end 2025-12
+uv run python -m nlp_arxiv_daily backfill --start 2024-01 --end 2025-12 --delay-seconds 15
 ```
 
-Idempotent — safe to re-run.
+Idempotent — safe to re-run. Run it in chunks (`--keywords "A,B,C"`, a few months at a time): arXiv rate-limits aggressively. A keyword with more than 2,000 papers a month hits arXiv's per-query result cap; add `--window-days 7` to query the month in weekly windows, and watch the log for `cap hit` if a window still overflows.
 
 ### 6. (Optional) Serve AdSense ads
 

--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -169,6 +169,29 @@ def _iter_month_ranges(start: datetime.date, end: datetime.date) -> Iterator[tup
         cur = next_first
 
 
+def _iter_windows(
+    month_start: datetime.date, month_end: datetime.date, window_days: int | None
+) -> list[tuple[datetime.date, datetime.date]]:
+    """Split one month into consecutive windows of `window_days` (the last one
+    clipped to month end). None, or a window longer than the month, yields
+    the whole month as a single range.
+
+    arxiv caps a query's result set (`max_results`, default 2000), and busy
+    keywords exceed that per month — LLM sat at ~2,000 rows for every month
+    since 2024-10 because of it. Narrower date windows keep each query under
+    the cap; the idempotent merge de-duplicates papers seen in two windows.
+    """
+    if window_days is None or window_days <= 0:
+        return [(month_start, month_end)]
+    windows = []
+    cur = month_start
+    while cur <= month_end:
+        last = min(cur + datetime.timedelta(days=window_days - 1), month_end)
+        windows.append((cur, last))
+        cur = last + datetime.timedelta(days=1)
+    return windows
+
+
 def cmd_backfill(
     config: dict,
     *,
@@ -177,6 +200,7 @@ def cmd_backfill(
     max_results: int = BACKFILL_DEFAULT_MAX_RESULTS,
     delay_seconds: int = BACKFILL_RATE_LIMIT_SECONDS,
     only_keywords: list[str] | None = None,
+    window_days: int | None = None,
 ) -> None:
     """Fetch every (keyword × month) in [start, end] and merge into the archive.
 
@@ -190,6 +214,10 @@ def cmd_backfill(
     `delay_seconds` overrides the per-request gap to dodge 429s on large runs.
     `only_keywords` restricts fetch to a subset of config keys — useful when
     seeding newly-added tags without re-querying the existing ones.
+    `window_days` splits each month into shorter date windows so a keyword
+    with more than `max_results` papers a month is not truncated (see
+    `_iter_windows`). A window that returns exactly `max_results` papers is
+    logged as a cap hit either way.
     """
     keywords = config["kv"]
     keyword_order = list(keywords.keys())
@@ -216,24 +244,40 @@ def cmd_backfill(
         # restarting the same range merges cleanly.
         month_data: list = []
         month_data_web: list = []
+        windows = _iter_windows(month_start, month_end, window_days)
         for topic, keyword in keywords.items():
             logging.info(f"Keyword: {topic}")
-            try:
-                papers = fetch_papers_in_range(
-                    query=keyword,
-                    start=month_start,
-                    end=month_end,
-                    max_results=max_results,
-                    delay_seconds=delay_seconds,
-                    known_code_links=known_code_links,
-                )
-            except Exception as e:
-                # One bad keyword × month must not kill the rest of the backfill.
-                tag = f"{month_start.strftime('%Y-%m')}/{topic}"
-                logging.warning(f"BACKFILL skip {tag}: {e}")
-                failed_queries.append(tag)
+            # Keyed by id so a paper returned by two neighbouring windows is
+            # stored once (the later window wins, same as the JSON merge).
+            papers_by_id: dict = {}
+            failed = False
+            for win_start, win_end in windows:
+                try:
+                    papers = fetch_papers_in_range(
+                        query=keyword,
+                        start=win_start,
+                        end=win_end,
+                        max_results=max_results,
+                        delay_seconds=delay_seconds,
+                        known_code_links=known_code_links,
+                    )
+                except Exception as e:
+                    # One bad keyword × window must not kill the rest of the backfill.
+                    tag = f"{win_start.isoformat()}..{win_end.isoformat()}/{topic}"
+                    logging.warning(f"BACKFILL skip {tag}: {e}")
+                    failed_queries.append(tag)
+                    failed = True
+                    continue
+                if len(papers) >= max_results:
+                    logging.warning(
+                        f"BACKFILL cap hit: {topic} {win_start.isoformat()}..{win_end.isoformat()} returned "
+                        f"{len(papers)} = max_results; results are truncated — use --window-days to split the month"
+                    )
+                for p in papers:
+                    papers_by_id[p.paper_id] = p
+            if failed and not papers_by_id:
                 continue
-            data, data_web = papers_to_legacy_rows(papers, topic)
+            data, data_web = papers_to_legacy_rows(list(papers_by_id.values()), topic)
             month_data.append(data)
             month_data_web.append(data_web)
 
@@ -305,6 +349,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="comma-separated subset of config keyword names to backfill (default: all)",
     )
+    backfill.add_argument(
+        "--window-days",
+        type=int,
+        default=None,
+        help=(
+            "split each month into windows of N days so busy keywords stay under --max-results "
+            "(default: one query per month)"
+        ),
+    )
     return parser
 
 
@@ -328,6 +381,7 @@ def main(argv: list[str] | None = None) -> int:
             max_results=args.max_results,
             delay_seconds=args.delay_seconds,
             only_keywords=only_keywords,
+            window_days=args.window_days,
         )
         return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -377,3 +377,119 @@ class TestBackfillDispatch:
     def test_backfill_requires_start(self, fake_config_file):
         with pytest.raises(SystemExit):
             cli.main(["--config_path", fake_config_file, "backfill"])
+
+
+class TestIterWindows:
+    """A month can be split into fixed-size windows so a busy keyword (LLM is
+    2,000+/month) is not truncated by the per-query result cap."""
+
+    def test_none_is_the_whole_month(self):
+        assert cli._iter_windows(datetime.date(2025, 8, 1), datetime.date(2025, 8, 31), None) == [
+            (datetime.date(2025, 8, 1), datetime.date(2025, 8, 31))
+        ]
+
+    def test_seven_day_windows_clip_at_month_end(self):
+        got = cli._iter_windows(datetime.date(2025, 8, 1), datetime.date(2025, 8, 31), 7)
+        assert got == [
+            (datetime.date(2025, 8, 1), datetime.date(2025, 8, 7)),
+            (datetime.date(2025, 8, 8), datetime.date(2025, 8, 14)),
+            (datetime.date(2025, 8, 15), datetime.date(2025, 8, 21)),
+            (datetime.date(2025, 8, 22), datetime.date(2025, 8, 28)),
+            (datetime.date(2025, 8, 29), datetime.date(2025, 8, 31)),
+        ]
+
+    def test_window_longer_than_month_is_the_whole_month(self):
+        assert cli._iter_windows(datetime.date(2026, 2, 1), datetime.date(2026, 2, 28), 45) == [
+            (datetime.date(2026, 2, 1), datetime.date(2026, 2, 28))
+        ]
+
+
+class TestBackfillWindows:
+    def _config(self, tmp_path):
+        json_dir = tmp_path / "docs"
+        json_dir.mkdir()
+        (json_dir / "archive-web").mkdir()
+        (json_dir / "main-web.json").write_text("{}")
+        return {
+            "kv": {"LLM": "all:LLM"},
+            "publish_readme": False,
+            "publish_gitpage": True,
+            "json_gitpage_path": str(json_dir / "main-web.json"),
+            "archive_gitpage_json_dir": str(json_dir / "archive-web"),
+            "show_badge": False,
+            "user_name": "u",
+            "repo_name": "r",
+        }
+
+    @staticmethod
+    def _paper(pid, day):
+        from nlp_arxiv_daily.types import Paper
+
+        return Paper(
+            paper_id=pid,
+            title=pid,
+            first_author="A",
+            update_time=datetime.date(2025, 8, day),
+            paper_url=f"http://arxiv.org/abs/{pid}v1",
+            code_link=None,
+            arxiv_short_id=f"{pid}v1",
+        )
+
+    def test_windows_are_fetched_separately_and_merged(self, monkeypatch, tmp_path):
+        import json
+
+        calls = []
+
+        def fake_fetch(query, start, end, **kw):
+            calls.append((start, end))
+            # Same paper returned by two neighbouring windows must be stored once.
+            return (
+                [self._paper("2508.00001", 7)]
+                if start.day == 1
+                else [self._paper("2508.00001", 7), self._paper(f"2508.{start.day:05d}", start.day)]
+            )
+
+        monkeypatch.setattr(cli, "fetch_papers_in_range", fake_fetch)
+        monkeypatch.setattr(cli, "cmd_render", lambda config: None)
+        config = self._config(tmp_path)
+        cli.cmd_backfill(config, start=datetime.date(2025, 8, 1), end=datetime.date(2025, 8, 1), window_days=10)
+
+        assert [(s.day, e.day) for s, e in calls] == [(1, 10), (11, 20), (21, 30), (31, 31)]
+        written = json.loads((tmp_path / "docs" / "archive-web" / "2025-08.json").read_text())
+        assert set(written["LLM"]) == {"2508.00001", "2508.00011", "2508.00021", "2508.00031"}
+
+    def test_warns_when_a_window_hits_the_result_cap(self, monkeypatch, tmp_path, caplog):
+        monkeypatch.setattr(
+            cli,
+            "fetch_papers_in_range",
+            lambda query, start, end, **kw: [self._paper("2508.00001", 1), self._paper("2508.00002", 2)],
+        )
+        monkeypatch.setattr(cli, "cmd_render", lambda config: None)
+        with caplog.at_level("WARNING"):
+            cli.cmd_backfill(
+                self._config(tmp_path), start=datetime.date(2025, 8, 1), end=datetime.date(2025, 8, 1), max_results=2
+            )
+        assert any("cap" in r.message and "LLM" in r.message for r in caplog.records)
+
+    def test_no_warning_below_cap(self, monkeypatch, tmp_path, caplog):
+        monkeypatch.setattr(
+            cli, "fetch_papers_in_range", lambda query, start, end, **kw: [self._paper("2508.00001", 1)]
+        )
+        monkeypatch.setattr(cli, "cmd_render", lambda config: None)
+        with caplog.at_level("WARNING"):
+            cli.cmd_backfill(
+                self._config(tmp_path), start=datetime.date(2025, 8, 1), end=datetime.date(2025, 8, 1), max_results=2
+            )
+        assert not any("cap" in r.message for r in caplog.records)
+
+    def test_cli_passes_window_days(self, monkeypatch, fake_config_file):
+        captured = {}
+        monkeypatch.setattr(cli, "cmd_backfill", lambda config, **kw: captured.update(kw))
+        cli.main(["--config_path", fake_config_file, "backfill", "--start", "2025-08", "--window-days", "7"])
+        assert captured["window_days"] == 7
+
+    def test_cli_window_days_defaults_to_none(self, monkeypatch, fake_config_file):
+        captured = {}
+        monkeypatch.setattr(cli, "cmd_backfill", lambda config, **kw: captured.update(kw))
+        cli.main(["--config_path", fake_config_file, "backfill", "--start", "2025-08"])
+        assert captured["window_days"] is None


### PR DESCRIPTION
## Why
arXiv caps a search at `max_results` (2,000 for backfill). Keywords like LLM exceed that in a month, so every backfilled LLM month since 2024-10 sits at 1,900–2,070 rows — the cap, not the real volume (September's pace suggests ~2,500/month).

## What
- `backfill --window-days N`: each month is split into consecutive N-day windows (last one clipped), one query per window, merged by paper id so a paper seen in two windows is stored once. Default unchanged (one query per month).
- A window that returns exactly `max_results` papers logs `BACKFILL cap hit … use --window-days`, so truncation is visible instead of silent.
- A failed window no longer discards the keyword's other windows.
- README gets a short backfill section.

## Test plan
- [x] TDD: `_iter_windows` (None / 7-day clipping / window longer than month), windows fetched separately and merged with de-duplication, cap warning present/absent, CLI pass-through and default
- [x] `make test` 171 passed, coverage 95%; `make quality` clean
- [ ] Follow-up data run: re-backfill LLM-heavy keywords from 2024-10 with `--window-days 7`, in chunks over several nights

🤖 Generated with [Claude Code](https://claude.com/claude-code)