### PR TITLE
fix(backfill): reuse one arxiv client so --delay-seconds actually spaces queries

### DIFF
--- a/nlp_arxiv_daily/cli.py
+++ b/nlp_arxiv_daily/cli.py
@@ -25,6 +25,7 @@ from nlp_arxiv_daily.fetcher import (
     DEFAULT_DAILY_LOOKBACK_DAYS,
     fetch_papers_in_range,
     fetch_recent_papers,
+    make_backfill_client,
 )
 from nlp_arxiv_daily.renderer import json_to_md, render_archive_pages
 from nlp_arxiv_daily.storage import load_known_code_links, write_papers_split
@@ -230,6 +231,9 @@ def cmd_backfill(
 
     months = list(_iter_month_ranges(start, end))
     known_code_links = _known_code_links(config)
+    # One client for the whole run: the library's rate limiter is per-client,
+    # so a fresh one per query would leave the queries themselves unspaced.
+    client = make_backfill_client(delay_seconds)
     logging.info(
         f"BACKFILL begin: {start.isoformat()} → {end.isoformat()} ({len(months)} months, "
         f"{len(known_code_links)} known papers)"
@@ -258,8 +262,8 @@ def cmd_backfill(
                         start=win_start,
                         end=win_end,
                         max_results=max_results,
-                        delay_seconds=delay_seconds,
                         known_code_links=known_code_links,
+                        client=client,
                     )
                 except Exception as e:
                     # One bad keyword × window must not kill the rest of the backfill.

--- a/nlp_arxiv_daily/fetcher.py
+++ b/nlp_arxiv_daily/fetcher.py
@@ -69,6 +69,20 @@ def _get_daily_client() -> arxiv.Client:
     return _DAILY_CLIENT
 
 
+def make_backfill_client(delay_seconds: int = BACKFILL_RATE_LIMIT_SECONDS) -> arxiv.Client:
+    """Build the client a backfill run should reuse for every query.
+
+    The arxiv library's rate limiter is per-client, so it only spaces requests
+    made through the same instance. A client built per query therefore spaces
+    the *pages* of that one query and nothing else — for a keyword whose month
+    fits in a single page, `delay_seconds` ends up doing nothing at all and the
+    queries go out back-to-back. Callers own the returned client and pass it to
+    every `fetch_papers_in_range` call in the run (cf. `_get_daily_client`,
+    which is a module singleton because the daily fetch is a single pass).
+    """
+    return arxiv.Client(delay_seconds=delay_seconds, num_retries=BACKFILL_NUM_RETRIES)
+
+
 def get_authors(authors: Iterable, first_author: bool = False) -> str:
     if first_author:
         return list(authors)[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,3 +493,61 @@ class TestBackfillWindows:
         monkeypatch.setattr(cli, "cmd_backfill", lambda config, **kw: captured.update(kw))
         cli.main(["--config_path", fake_config_file, "backfill", "--start", "2025-08"])
         assert captured["window_days"] is None
+
+
+class TestBackfillSharedClient:
+    """The arxiv library's rate limiter lives on the client, so the backfill
+    has to reuse one across queries. A fresh client per query only spaces the
+    *pages* of a single query, which leaves `--delay-seconds` doing nothing
+    for keywords that fit in one page."""
+
+    def _config(self, tmp_path):
+        json_dir = tmp_path / "docs"
+        json_dir.mkdir()
+        (json_dir / "archive-web").mkdir()
+        (json_dir / "main-web.json").write_text("{}")
+        return {
+            "kv": {"LLM": "all:LLM", "NLP": "all:NLP"},
+            "publish_readme": False,
+            "publish_gitpage": True,
+            "json_gitpage_path": str(json_dir / "main-web.json"),
+            "archive_gitpage_json_dir": str(json_dir / "archive-web"),
+            "show_badge": False,
+            "user_name": "u",
+            "repo_name": "r",
+        }
+
+    def _run(self, monkeypatch, tmp_path, **kw):
+        clients = []
+
+        def fake_fetch(query, start, end, **kwargs):
+            clients.append(kwargs.get("client"))
+            return []
+
+        monkeypatch.setattr(cli, "fetch_papers_in_range", fake_fetch)
+        monkeypatch.setattr(cli, "cmd_render", lambda config: None)
+        cli.cmd_backfill(
+            self._config(tmp_path),
+            start=datetime.date(2025, 8, 1),
+            end=datetime.date(2025, 9, 1),
+            **kw,
+        )
+        return clients
+
+    def test_one_client_is_shared_by_every_query(self, monkeypatch, tmp_path):
+        clients = self._run(monkeypatch, tmp_path, window_days=15)
+        # 2 keywords × (August: 1-15, 16-30, 31 + September: 1-15, 16-30)
+        assert len(clients) == 10
+        assert all(c is not None for c in clients)
+        assert len({id(c) for c in clients}) == 1
+
+    def test_client_is_built_with_the_requested_delay(self, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_make(delay_seconds):
+            captured["delay_seconds"] = delay_seconds
+            return object()
+
+        monkeypatch.setattr(cli, "make_backfill_client", fake_make)
+        self._run(monkeypatch, tmp_path, delay_seconds=15)
+        assert captured["delay_seconds"] == 15

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -654,3 +654,24 @@ class TestFetchRecentPapers:
         captured = _patch_arxiv(monkeypatch, [])
         fetch_recent_papers("x", lookback_days=1, max_results=10, today=datetime.date(2026, 9, 8))
         assert "submittedDate:[202609080000 TO 202609082359]" in captured["search"].query
+
+
+class TestMakeBackfillClient:
+    def test_carries_the_requested_delay_and_retries(self, monkeypatch):
+        captured = _patch_arxiv(monkeypatch, [])
+        fetcher.make_backfill_client(delay_seconds=15)
+        kwargs = captured["client_kwargs"]
+        assert kwargs["delay_seconds"] == 15
+        # Library default is 3; bump so transient 429s don't kill a long run.
+        assert kwargs.get("num_retries", 0) >= 10
+
+    def test_defaults_to_the_backfill_rate_limit(self, monkeypatch):
+        captured = _patch_arxiv(monkeypatch, [])
+        fetcher.make_backfill_client()
+        assert captured["client_kwargs"]["delay_seconds"] == fetcher.BACKFILL_RATE_LIMIT_SECONDS
+
+    def test_returns_a_new_client_each_call(self, monkeypatch):
+        _patch_arxiv(monkeypatch, [])
+        # Unlike the daily singleton, the backfill client is per-run: the
+        # caller owns it and passes it to every fetch_papers_in_range call.
+        assert fetcher.make_backfill_client() is not fetcher.make_backfill_client()


### PR DESCRIPTION
## The bug

`fetch_papers_in_range` builds an `arxiv.Client` per call unless one is passed in, and `cmd_backfill` never passed one. The library's rate limiter is per-client, so the delay only applied *between the pages of a single query* — the queries themselves went out back-to-back.

For a keyword whose month fits in one page, that means `--delay-seconds` did literally nothing.

It hid behind the runs that motivated the flag: LLM months are 20+ pages, so the in-query spacing dominated and the backfill looked well-behaved. The classic keywords are one page a month, and the 2023-01~2024-05 backfill (#85, #86, #87) went out at roughly a query a second. No 429s — but that was luck, not the flag.

## The fix

`make_backfill_client(delay_seconds)` in `fetcher.py`, called once in `cmd_backfill` and passed to every `fetch_papers_in_range` call — the same shape as `_get_daily_client`, except the caller owns it since a backfill is one bounded run rather than a process-wide singleton.

Not a module singleton on purpose: two runs in one process would otherwise share (and fight over) one limiter, and `--delay-seconds` would be pinned by whichever run started first.

## Tests

Written first, red before the change:

- `TestBackfillSharedClient::test_one_client_is_shared_by_every_query` — every query across 2 keywords × 2 months × windows receives the same client instance.
- `TestBackfillSharedClient::test_client_is_built_with_the_requested_delay` — `--delay-seconds` reaches the client factory.
- `TestMakeBackfillClient` — delay/retries land on the client, the default is `BACKFILL_RATE_LIMIT_SECONDS`, and each call returns a fresh client.

`176 passed`, coverage 95%. `ruff check` / `ruff format --check` clean.

## What changes in practice

Backfills get slower and safer: a 26-keyword month is now at least 26 × `--delay-seconds` instead of firing 26 queries as fast as arXiv answers. That is the behaviour the flag always advertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
